### PR TITLE
Fixes error "Invalid username or password for SceneAccess Check your set...

### DIFF
--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -240,9 +240,7 @@ class SCCProvider(generic.TorrentProvider):
             parsed = list(urlparse.urlparse(url))
             parsed[2] = re.sub("/{2,}", "/", parsed[2])  # replace two or more / with one
             url = urlparse.urlunparse(parsed)
-			
-			
-			
+
             response = self.session.get(url, headers=headers, verify=False)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
             logger.log(u"Error loading " + self.name + " URL: " + ex(e), logger.ERROR)


### PR DESCRIPTION
...tings"

I took this fix from the mr-orange fork from my old setup since SceneAccess won't let you through without headers.
