### PR TITLE
Utorrent: Add high priority mode

### DIFF
--- a/sickbeard/clients/utorrent.py
+++ b/sickbeard/clients/utorrent.py
@@ -63,6 +63,12 @@ class uTorrentAPI(GenericClient):
                   'v': sickbeard.TORRENT_LABEL
         }
         return self._request(params=params)
+        
+    def _set_torrent_priority(self, result):
+
+        if result.priority == 1:
+            params = {'action': 'queuetop', 'hash': result.hash}
+            return self._request(params=params)        
 
     def _set_torrent_pause(self, result):
 


### PR DESCRIPTION
Adds high priority mode for recently aired shows to utorrent using already existing checkbox under "search options\episode search".
