### PR TITLE
Fixed 'NoneType' object has no attribute 'status' error

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -816,8 +816,8 @@ class PostProcessor(object):
 
         # try to find the file info
         (indexer_id, season, episodes) = self._find_info()
-        if not (indexer_id or season or episodes):
-            self._log(u"Can't find thhe show on any of the Indexers, skipping",
+        if not (indexer_id and season and len(episodes)):
+            self._log(u"Can't find the show on any of the Indexers, skipping",
                       logger.WARNING)
             return False
 


### PR DESCRIPTION
Thanks @echel0n for the new commit, tried it but it doesn't seem to fix #214

Not 100% sure with Python's syntax, as I've never really worked with it before, but I'm pretty sure the condition should say we don't want to continue if we're missing any of the indexer_id or season or the episode.

Fixes the error for me anyways :)

Re-created the pull request because I did the pull request from my dev branch instead of creating one for this issue.
