### PR TITLE
Added best-hd quality for 720p initially and 1080p as archive

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -89,7 +89,7 @@ class Quality:
     RAWHDTV = 1 << 3  # 8  -- 720p/1080i mpeg2 (trollhd releases)
     FULLHDTV = 1 << 4  # 16 -- 1080p HDTV (QCF releases)
     HDWEBDL = 1 << 5  # 32
-    FULLHDWEBDL = 1 << 6  # 64 -- 1080p web-dl                        
+    FULLHDWEBDL = 1 << 6  # 64 -- 1080p web-dl
     HDBLURAY = 1 << 7  # 128
     FULLHDBLURAY = 1 << 8  # 256
 
@@ -168,7 +168,7 @@ class Quality:
     @staticmethod
     def sceneQuality(name):
         """
-        Return The quality from the scene episode File 
+        Return The quality from the scene episode File
         """
 
         name = os.path.basename(name)
@@ -273,7 +273,7 @@ BEST_HD = Quality.combineQualities(
     [Quality.FULLHDTV, Quality.FULLHDWEBDL, Quality.FULLHDBLURAY],
 )
 
-qualityPresets = (SD, HD, HD720p, HD1080p, ANY)
+qualityPresets = (SD, HD, HD720p, HD1080p, BEST_HD, ANY)
 qualityPresetStrings = {SD: "SD",
                         HD: "HD",
                         HD720p: "HD720p",


### PR DESCRIPTION
With most of my series I like to download and watch them as they come out, but it can take quite a while before the high quality releases are available (i.e. Blu-ray) which I do like for archiving.
