### PR TITLE
Fix typo in db.py

### DIFF
--- a/sickbeard/db.py
+++ b/sickbeard/db.py
@@ -129,7 +129,7 @@ class DBConnection:
                                 logger.log(qu[0] + " with args " + str(qu[1]), logger.DEBUG)
                             sqlResult.append(self.connection.execute(qu[0], qu[1]))
                     self.connection.commit()
-                    logger.log(u"Transaction with " + str(len(querylist)) + u" query's executed", logger.DEBUG)
+                    logger.log(u"Transaction with " + str(len(querylist)) + u" queries executed", logger.DEBUG)
                     return sqlResult
                 except sqlite3.OperationalError, e:
                     sqlResult = []


### PR DESCRIPTION
Fixing just one typo ("query's" to "queries"), after staring at it on my screen for the last few hours :)
