### PR TITLE
Add proper handling for reverse proxies

### DIFF
--- a/gui/slick/interfaces/default/config_general.tmpl
+++ b/gui/slick/interfaces/default/config_general.tmpl
@@ -129,6 +129,14 @@
                             </label>
                         </div>
 
+                        <div class="field-pair">
+                            <input type="checkbox" name="handle_reverse_proxy" id="handle_reverse_proxy" #if $sickbeard.HANDLE_REVERSE_PROXY then "checked=\"checked\"" else ""#/>
+                            <label class="clearfix" for="handle_reverse_proxy">
+                                <span class="component-title">Handle reverse proxies</span>
+                                <span class="component-desc">Should Sick Beard accept reverse proxy headers? (X-Forwarded-Host, X-Forwarded-For, X-Forwarded-Proto)</span>
+                            </label>
+                        </div>
+
                         <input type="submit" class="btn config_submitter" value="Save Changes" />
                     </fieldset>
                 </div><!-- /component-group1 //-->

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -461,7 +461,7 @@ def initialize(consoleLogging=True):
     with INIT_LOCK:
 
         global ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, ENCRYPTION_VERSION, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
-            USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, PREFER_EPISODE_RELEASES, ALLOW_HIGH_PRIORITY, TORRENT_METHOD, \
+            HANDLE_REVERSE_PROXY, USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, PREFER_EPISODE_RELEASES, ALLOW_HIGH_PRIORITY, TORRENT_METHOD, \
             SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
             NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
             TORRENT_USERNAME, TORRENT_PASSWORD, TORRENT_HOST, TORRENT_PATH, TORRENT_RATIO, TORRENT_SEED_TIME, TORRENT_PAUSED, TORRENT_HIGH_BANDWIDTH, TORRENT_LABEL, \
@@ -571,6 +571,8 @@ def initialize(consoleLogging=True):
 
         HTTPS_CERT = check_setting_str(CFG, 'General', 'https_cert', 'server.crt')
         HTTPS_KEY = check_setting_str(CFG, 'General', 'https_key', 'server.key')
+
+        HANDLE_REVERSE_PROXY = bool(check_setting_int(CFG, 'General', 'handle_reverse_proxy', 0))
 
         ACTUAL_CACHE_DIR = check_setting_str(CFG, 'General', 'cache_dir', 'cache')
         # fix bad configs due to buggy code
@@ -1313,6 +1315,7 @@ def save_config():
     new_config['General']['enable_https'] = int(ENABLE_HTTPS)
     new_config['General']['https_cert'] = HTTPS_CERT
     new_config['General']['https_key'] = HTTPS_KEY
+    new_config['General']['handle_reverse_proxy'] = int(HANDLE_REVERSE_PROXY)
     new_config['General']['use_nzbs'] = int(USE_NZBS)
     new_config['General']['use_torrents'] = int(USE_TORRENTS)
     new_config['General']['nzb_method'] = NZB_METHOD

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -32,7 +32,9 @@ import itertools
 import operator
 
 from Cheetah.Template import Template
+import cherrypy
 import cherrypy.lib
+import cherrypy.lib.cptools
 
 import sickbeard
 
@@ -79,6 +81,11 @@ except ImportError:
 
 from sickbeard import browser
 
+def _handle_reverse_proxy():
+    if sickbeard.HANDLE_REVERSE_PROXY:
+        cherrypy.lib.cptools.proxy()
+
+cherrypy.tools.handle_reverse_proxy = cherrypy.Tool('before_handler', _handle_reverse_proxy)
 
 class PageTemplate(Template):
     def __init__(self, *args, **KWs):
@@ -976,7 +983,7 @@ class ConfigGeneral:
     def saveGeneral(self, log_dir=None, web_port=None, web_log=None, encryption_version=None, web_ipv6=None,
                     update_shows_on_start=None, update_frequency=None, launch_browser=None, web_username=None, use_api=None, api_key=None,
                     web_password=None, version_notify=None, enable_https=None, https_cert=None, https_key=None,
-                    sort_article=None, auto_update=None, proxy_setting=None,
+                    handle_reverse_proxy=None, sort_article=None, auto_update=None, proxy_setting=None,
                     anon_redirect=None, git_path=None, calendar_unprotected=None, date_preset=None, time_preset=None, indexer_default=None):
 
         results = []
@@ -1029,6 +1036,8 @@ class ConfigGeneral:
         if not config.change_HTTPS_KEY(https_key):
             results += [
                 "Unable to create directory " + os.path.normpath(https_key) + ", https key directory not changed."]
+
+        sickbeard.HANDLE_REVERSE_PROXY = config.checkbox_to_value(handle_reverse_proxy)
 
         sickbeard.save_config()
 

--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -135,6 +135,7 @@ def initWebServer(options={}):
             'tools.staticdir.root': options['data_root'],
             'tools.encode.on': True,
             'tools.encode.encoding': 'utf-8',
+            'tools.handle_reverse_proxy.on': True,
         },
         '/images': {
             'tools.staticdir.on': True,


### PR DESCRIPTION
This pull requests adds the option to enable proper handling for reverse proxies, [as done by cherrypy](http://cherrypy.readthedocs.org/en/latest/refman/lib/cptools.html#cherrypy.lib.cptools.proxy).

Currently, it enables handling of the headers:
- `X-Forwarded-Host` - The host received by the proxy
- `X-Forwarded-For` - The IP address connecting to the proxy
- `X-Forwarded-Proto` - The protocol received by the proxy

(This is a copy of #357 based against dev)
