### PR TITLE
Adds Per Provider Seed Ratio

### DIFF
--- a/gui/slick/interfaces/default/config_providers.tmpl
+++ b/gui/slick/interfaces/default/config_providers.tmpl
@@ -172,6 +172,15 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                         </div>
                     </div><!-- /omgwtfnzbsDiv //-->
 
+<div class="providerDiv" id="ezrssDiv">
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="ezrss_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="ezrss_ratio" id="ezrss_ratio" value="$sickbeard.EZRSS_RATIO" size="40" />
+                            </label>
+                        </div>
+</div>
+
 <div class="providerDiv" id="tvtorrentsDiv">
                         <div class="field-pair">
                             <label class="clearfix">
@@ -185,39 +194,23 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                                 <input class="component-desc" type="text" name="tvtorrents_hash" value="$sickbeard.TVTORRENTS_HASH" size="40" />
                             </label>
                         </div>
-                        <div style="width: 340px; padding-bottom: 10px !important;">
-						<input type="hidden" id="tvtorrents_option_string" />
-						<fieldset style="display: block; border-width: 1px !important; border-radius: 5px !important; border-color: #D0D0D0 !important; border-style: solid !important;">
-						<legend id="seed_options">Advanced Options</legend>
-						<div class="field-pair" style="margin-top: -2px !important;">
-                            <label class="clearfix" >
-                                <span class="component-title" style="width: 130px !important;">Seeding Goal Ratio(%):</span>
-                                <input class="seed_option" type="text" id="tvtorrents_seed_ratio" size="5" style="margin-left: -5px !important;"/>
-                            </label>
-                        </div>
-						<div class="field-pair" style="margin-top: -10px !important;">
+
+                        <div class="field-pair">
                             <label class="clearfix">
-                                <span class="component-title" style="width: 130px !important;">Seeding Goal Time(h):</span>
-                                <input class="seed_option" type="text" id="tvtorrents_seed_time" size="5"  style="margin-left: -5px !important;" />
+                                <span class="component-title" id="tvtorrents_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="tvtorrents_ratio" id="tvtorrents_ratio" value="$sickbeard.TVTORRENTS_RATIO" size="40" />
                             </label>
-                        </div>
-                        <div style="display: block; text-align: center;margin-top: -10px !important;" class="float-left">
-                                <label class="clearfix">
-                                <span class="component-title" style="margin-left: -49px !important; width: 201px !important;">Process Method:</span>
-                                    <select class="seed_option" id="tvtorrents_process_method" class="input-medium" >
-                                        #set $process_method_text = {'': "", 'copy': "Copy", 'move': "Move", 'hardlink': "Hard Link", 'symlink' : "Symbolic Link"}
-                                        #for $curAction in ('', 'copy', 'move', 'hardlink', 'symlink'):
-                                        #set $process_method = ""
-                                        <option class="seed_option" value="$curAction" $process_method>$process_method_text[$curAction]</option>
-                                        #end for
-                                    </select>                                
-								</label>
-						</div>                                     
-						</fieldset>
                         </div>
 </div>
 
 <div class="providerDiv" id="thepiratebayDiv">
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="thepiratebay_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="thepiratebay_ratio" id="thepiratebay_ratio" value="$sickbeard.THEPIRATEBAY_RATIO" size="40" />
+                            </label>
+                        </div>
+
                         <div class="field-pair">
                             <input type="checkbox" class="enabler" name="thepiratebay_proxy" id="thepiratebay_proxy" #if $sickbeard.THEPIRATEBAY_PROXY then "checked=\"checked\"" else ""#/>
                             <label class="clearfix">
@@ -250,10 +243,26 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
 
 <div class="providerDiv" id="kickasstorrentsDiv">
                         <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="kat_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="kat_ratio" id="kat_ratio" value="$sickbeard.KAT_RATIO" size="40" />
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
                             <input type="checkbox" name="kat_verified" id="kat_verified" #if $sickbeard.KAT_VERIFIED then "checked=\"checked\"" else ""#/>
                             <label class="clearfix" for="kat_verified">
                                 <span class="component-title">Verified Only</span>
                                 <span class="component-desc">Download only verified torrent?</span>
+                            </label>
+                        </div>
+</div>
+
+<div class="providerDiv" id="publichdDiv">
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="publichd_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="publichd_ratio" id="publichd_ratio" value="$sickbeard.PUBLICHD_RATIO" size="40" />
                             </label>
                         </div>
 </div>
@@ -263,6 +272,12 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                             <label class="clearfix">
                                 <span class="component-title">Api Key:</span>
                                 <input class="component-desc" type="text" name="btn_api_key" value="$sickbeard.BTN_API_KEY" size="40" />
+                            </label>
+                        </div>
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="btn_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="btn_ratio" id="btn_ratio" value="$sickbeard.BTN_RATIO" size="40" />
                             </label>
                         </div>
 </div>
@@ -280,6 +295,12 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                                 <input class="component-desc" type="password" name="torrentleech_password" value="$sickbeard.TORRENTLEECH_PASSWORD" size="40" />
                             </label>
                         </div>
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="torrentleech_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="torrentleech_ratio" id="torrentleech_ratio" value="$sickbeard.TORRENTLEECH_RATIO" size="40" />
+                            </label>
+                        </div>
 </div>
 
 <div class="providerDiv" id="iptorrentsDiv">
@@ -293,6 +314,12 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                             <label class="clearfix">
                                 <span class="component-title">Password:</span>
                                 <input class="component-desc" type="password" name="iptorrents_password" value="$sickbeard.IPTORRENTS_PASSWORD" size="40" />
+                            </label>
+                        </div>
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="iptorrents_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="iptorrents_ratio" id="iptorrents_ratio" value="$sickbeard.IPTORRENTS_RATIO" size="40" />
                             </label>
                         </div>
                         <div class="field-pair">
@@ -317,6 +344,12 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                                 <input class="component-desc" type="password" name="scc_password" value="$sickbeard.SCC_PASSWORD" size="40" />
                             </label>
                         </div>
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="scc_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="scc_ratio" id="scc_ratio" value="$sickbeard.SCC_RATIO" size="40" />
+                            </label>
+                        </div>
 </div><!-- /sceneaccessDiv //-->
 
 <div class="providerDiv" id="hdtorrentsDiv">
@@ -332,6 +365,12 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                                 <input class="component-desc" type="password" name="hdtorrents_password" value="$sickbeard.HDTORRENTS_PASSWORD" size="40" />
                             </label>
                         </div>
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="hdtorrents_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="hdtorrents_ratio" id="hdtorrents_ratio" value="$sickbeard.HDTORRENTS_RATIO" size="40" />
+                            </label>
+                        </div>
 </div><!-- /sceneaccessDiv //-->
 
 <div class="providerDiv" id="torrentdayDiv">
@@ -345,6 +384,12 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                             <label class="clearfix">
                                 <span class="component-title">Password:</span>
                                 <input class="component-desc" type="password" name="torrentday_password" value="$sickbeard.TORRENTDAY_PASSWORD" size="40" />
+                            </label>
+                        </div>
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="torrentday_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="torrentday_ratio" id="torrentday_ratio" value="$sickbeard.TORRENTDAY_RATIO" size="40" />
                             </label>
                         </div>
                         <div class="field-pair">
@@ -369,6 +414,12 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                                 <input class="component-desc" type="password" name="nextgen_password" value="$sickbeard.NEXTGEN_PASSWORD" size="40" />
                             </label>
                         </div>
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="nextgen_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="nextgen_ratio" id="nextgen_ratio" value="$sickbeard.NEXTGEN_RATIO" size="40" />
+                            </label>
+                        </div>
 </div><!-- /nextgenDiv //-->
 
 <div class="providerDiv" id="hdbitsDiv">
@@ -384,9 +435,15 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                                 <input class="component-desc" type="text" name="hdbits_passkey" value="$sickbeard.HDBITS_PASSKEY" size="40" />
                             </label>
                         </div>
-                    </div><!-- /hdbitsDiv //-->   
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="hdbits_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="hdbits_ratio" id="hdbits_ratio" value="$sickbeard.HDBITS_RATIO" size="40" />
+                            </label>
+                        </div>
+</div><!-- /hdbitsDiv //-->   
 
-                    <div class="providerDiv" id="speedcdDiv">
+<div class="providerDiv" id="speedcdDiv">
                         <div class="field-pair">
                             <label class="clearfix">
                                 <span class="component-title">Username:</span>
@@ -400,13 +457,19 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                             </label>
                         </div>
                         <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title" id="speedcd_ratio_desc">Seed Ratio:</span>
+                                <input type="text" name="speedcd_ratio" id="speedcd_ratio" value="$sickbeard.SPEEDCD_RATIO" size="40" />
+                            </label>
+                        </div>
+                        <div class="field-pair">
                             <input type="checkbox" name="speedcd_freeleech" id="speedcd_freeleech" #if $sickbeard.SPEEDCD_FREELEECH then "checked=\"checked\"" else ""#/>
                             <label class="clearfix" for="iptorrents_freeleech">
                                 <span class="component-title">FreeLeech</span>
                                 <span class="component-desc">This will only download <b>[FreeLeech]</b> torrents.</span>
                             </label>
                         </div>
-                    </div><!-- /speedcdDiv //-->
+</div><!-- /speedcdDiv //-->
 
 <!-- end div for editing providers -->
 

--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -367,9 +367,9 @@
                                     <span class="component-title">&nbsp;</span>
                                     <span class="component-desc">Add a specific label to Torrent</span>
                                 </label>
-                                <label class="nocheck clearfix" id="deluge_label_warning">
+                                <label class="nocheck clearfix" id="label_warning">
                                     <span class="component-title">&nbsp;</span>
-                                    <span class="component-desc"><b>Note:</b> Label plugin must be enabled in Deluge client</span>
+                                    <span class="component-desc"><b>Note:</b> Adds specific warning to Torrent label</span>
                                 </label>
                             </div>
 

--- a/gui/slick/js/configSearch.js
+++ b/gui/slick/js/configSearch.js
@@ -50,6 +50,7 @@ $(document).ready(function(){
             $('#Torrent_Seed_Time').show();
             $('#Torrent_High_Bandwidth').hide();
             $('#Torrent_Label').show();
+            $('#label_warning').text('');
             $('#host_desc').text('uTorrent Host');
             $('#username_desc').text('uTorrent Username');
             $('#password_desc').text('uTorrent Password');
@@ -80,6 +81,7 @@ $(document).ready(function(){
             $('#username_desc').text('Deluge Username');
             $('#password_desc').text('Deluge Password');
             $('#label_desc').text('Deluge Label');
+            $('#label_warning').text('Note: Label plugin must be enabled in Deluge client. No blank spaces are allowed in label name');
             $('#directory_desc').text('Deluge Directory');
         } else if (selectedProvider == "download_station"){
             $('#t_blackhole_settings').hide();
@@ -103,13 +105,14 @@ $(document).ready(function(){
             $('#Torrent_username').show();
             $('#Torrent_Paused').hide();
             $('#Torrent_Path').show();
-            $('#Torrent_Ratio').show();
+            $('#Torrent_Ratio').hide();
             $('#Torrent_Seed_Time').hide();
             $('#Torrent_High_Bandwidth').hide();
             $('#host_desc').text('rTorrent Host');
             $('#username_desc').text('rTorrent Username');
             $('#password_desc').text('rTorrent Password');
             $('#label_desc').text('rTorrent Label');
+            $('#label_warning').text('');
             $('#directory_desc').text('rTorrent Directory');
         }
     }

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -179,17 +179,21 @@ DEFAULT_SEARCH_FREQUENCY = 40
 DEFAULT_UPDATE_FREQUENCY = 12
 
 EZRSS = False
+EZRSS_RATIO = ''
 
 TVTORRENTS = False
 TVTORRENTS_DIGEST = None
 TVTORRENTS_HASH = None
+TVTORRENTS_RATIO = ''
 
 BTN = False
 BTN_API_KEY = None
+BTN_RATIO = ''
 
 NEWZNAB_DATA = None
 
 THEPIRATEBAY = False
+THEPIRATEBAY_RATIO = ''
 THEPIRATEBAY_TRUSTED = False
 THEPIRATEBAY_PROXY = False
 THEPIRATEBAY_PROXY_URL = None
@@ -199,35 +203,43 @@ TORRENTLEECH = False
 TORRENTLEECH_KEY = None
 TORRENTLEECH_USERNAME = None
 TORRENTLEECH_PASSWORD = None
+TORRENTLEECH_RATIO = ''
 
 IPTORRENTS = False
 IPTORRENTS_USERNAME = None
 IPTORRENTS_PASSWORD = None
+IPTORRENTS_RATIO = ''
 IPTORRENTS_FREELEECH = False
 
 NEXTGEN = False
 NEXTGEN_USERNAME = None
 NEXTGEN_PASSWORD = None
+NEXTGEN_RATIO = ''
 NEXTGEN_FREELEECH = False
 
 KAT = None
+KAT_RATIO = ''
 KAT_VERIFIED = False
 
 PUBLICHD = None
+PUBLICHD_RATIO = ''
 
 SCC = False
 SCC_USERNAME = None
 SCC_PASSWORD = None
+SCC_RATIO = ''
 
 HDTORRENTS = False
 HDTORRENTS_USERNAME = None
 HDTORRENTS_PASSWORD = None
+HDTORRENTS_RATIO = ''
 HDTORRENTS_UID = None
 HDTORRENTS_HASH = None
 
 TORRENTDAY = None
 TORRENTDAY_USERNAME = None
 TORRENTDAY_PASSWORD = None
+TORRENTDAY_RATIO = ''
 TORRENTDAY_UID = None
 TORRENTDAY_HASH = None
 TORRENTDAY_FREELEECH = None
@@ -235,10 +247,12 @@ TORRENTDAY_FREELEECH = None
 HDBITS = False
 HDBITS_USERNAME = None
 HDBITS_PASSKEY = None
+HDBITS_RATIO = ''
 
 SPEEDCD = False
 SPEEDCD_USERNAME = None
 SPEEDCD_PASSWORD = None
+SPEEDCD_RATIO = ''
 SPEEDCD_FREELEECH = None
 
 ADD_SHOWS_WO_DIR = None
@@ -470,11 +484,13 @@ def initialize(consoleLogging=True):
             USE_PLEX, PLEX_NOTIFY_ONSNATCH, PLEX_NOTIFY_ONDOWNLOAD, PLEX_NOTIFY_ONSUBTITLEDOWNLOAD, PLEX_UPDATE_LIBRARY, \
             PLEX_SERVER_HOST, PLEX_HOST, PLEX_USERNAME, PLEX_PASSWORD, \
             showUpdateScheduler, __INITIALIZED__, LAUNCH_BROWSER, UPDATE_SHOWS_ON_START, SORT_ARTICLE, showList, loadingShowList, \
-            NEWZNAB_DATA, NZBS, NZBS_UID, NZBS_HASH, EZRSS, TVTORRENTS, TVTORRENTS_DIGEST, TVTORRENTS_HASH, TVTORRENTS_OPTIONS, BTN, BTN_API_KEY, BTN_OPTIONS, \
-            THEPIRATEBAY, THEPIRATEBAY_TRUSTED, THEPIRATEBAY_PROXY, THEPIRATEBAY_PROXY_URL, THEPIRATEBAY_BLACKLIST, THEPIRATEBAY_OPTIONS, TORRENTLEECH, TORRENTLEECH_USERNAME, TORRENTLEECH_PASSWORD, TORRENTLEECH_OPTIONS, \
-            IPTORRENTS, IPTORRENTS_USERNAME, IPTORRENTS_PASSWORD, IPTORRENTS_FREELEECH, IPTORRENTS_OPTIONS, KAT, KAT_VERIFIED, KAT_OPTIONS, PUBLICHD, PUBLICHD_OPTIONS, SCC, SCC_USERNAME, SCC_PASSWORD, SCC_OPTIONS, HDTORRENTS, HDTORRENTS_USERNAME, HDTORRENTS_PASSWORD, HDTORRENTS_UID, HDTORRENTS_HASH, HDTORRENTS_OPTIONS, TORRENTDAY, TORRENTDAY_USERNAME, TORRENTDAY_PASSWORD, TORRENTDAY_UID, TORRENTDAY_HASH, TORRENTDAY_FREELEECH, TORRENTDAY_OPTIONS, \
-            HDBITS, HDBITS_USERNAME, HDBITS_PASSKEY, HDBITS_OPTIONS, TORRENT_DIR, USENET_RETENTION, SOCKET_TIMEOUT, SEARCH_FREQUENCY, DEFAULT_SEARCH_FREQUENCY, BACKLOG_SEARCH_FREQUENCY, INDEXER_DEFAULT, \
-            NEXTGEN, NEXTGEN_USERNAME, NEXTGEN_PASSWORD, NEXTGEN_FREELEECH, NEXTGEN_OPTIONS, SPEEDCD, SPEEDCD_USERNAME, SPEEDCD_PASSWORD, SPEEDCD_FREELEECH,\
+            NEWZNAB_DATA, NZBS, NZBS_UID, NZBS_HASH, EZRSS, EZRSS_RATIO, TVTORRENTS, TVTORRENTS_DIGEST, TVTORRENTS_HASH, TVTORRENTS_RATIO, TVTORRENTS_OPTIONS, BTN, BTN_API_KEY, BTN_RATIO, BTN_OPTIONS, \
+            THEPIRATEBAY, THEPIRATEBAY_RATIO, THEPIRATEBAY_TRUSTED, THEPIRATEBAY_PROXY, THEPIRATEBAY_PROXY_URL, THEPIRATEBAY_BLACKLIST, THEPIRATEBAY_OPTIONS, TORRENTLEECH, TORRENTLEECH_USERNAME, TORRENTLEECH_PASSWORD, TORRENTLEECH_RATIO, TORRENTLEECH_OPTIONS, \
+            IPTORRENTS, IPTORRENTS_USERNAME, IPTORRENTS_PASSWORD, IPTORRENTS_RATIO, IPTORRENTS_FREELEECH, IPTORRENTS_OPTIONS, KAT, KAT_RATIO, KAT_VERIFIED, KAT_OPTIONS, PUBLICHD, PUBLICHD_RATIO, PUBLICHD_OPTIONS, \
+            SCC, SCC_USERNAME, SCC_PASSWORD, SCC_RATIO, SCC_OPTIONS, HDTORRENTS, HDTORRENTS_USERNAME, HDTORRENTS_PASSWORD, HDTORRENTS_RATIO, HDTORRENTS_UID, HDTORRENTS_HASH, HDTORRENTS_OPTIONS, \
+            TORRENTDAY, TORRENTDAY_USERNAME, TORRENTDAY_PASSWORD, TORRENTDAY_RATIO, TORRENTDAY_UID, TORRENTDAY_HASH, TORRENTDAY_FREELEECH, TORRENTDAY_OPTIONS, \
+            HDBITS, HDBITS_USERNAME, HDBITS_PASSKEY, HDBITS_RATIO, HDBITS_OPTIONS, TORRENT_DIR, USENET_RETENTION, SOCKET_TIMEOUT, SEARCH_FREQUENCY, DEFAULT_SEARCH_FREQUENCY, BACKLOG_SEARCH_FREQUENCY, INDEXER_DEFAULT, \
+            NEXTGEN, NEXTGEN_USERNAME, NEXTGEN_PASSWORD, NEXTGEN_RATIO, NEXTGEN_FREELEECH, NEXTGEN_OPTIONS, SPEEDCD, SPEEDCD_USERNAME, SPEEDCD_PASSWORD, SPEEDCD_RATIO, SPEEDCD_FREELEECH,\
             QUALITY_DEFAULT, FLATTEN_FOLDERS_DEFAULT, SUBTITLES_DEFAULT, STATUS_DEFAULT, \
             GROWL_NOTIFY_ONSNATCH, GROWL_NOTIFY_ONDOWNLOAD, GROWL_NOTIFY_ONSUBTITLEDOWNLOAD, TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, TWITTER_NOTIFY_ONSUBTITLEDOWNLOAD, \
             USE_GROWL, GROWL_HOST, GROWL_PASSWORD, USE_PROWL, PROWL_NOTIFY_ONSNATCH, PROWL_NOTIFY_ONDOWNLOAD, PROWL_NOTIFY_ONSUBTITLEDOWNLOAD, PROWL_API, PROWL_PRIORITY, PROG_DIR, \
@@ -656,17 +672,21 @@ def initialize(consoleLogging=True):
         EZRSS = bool(check_setting_int(CFG, 'General', 'use_torrent', 0))
         if not EZRSS:
             EZRSS = bool(check_setting_int(CFG, 'EZRSS', 'ezrss', 0))
+        EZRSS_RATIO = check_setting_str(CFG, 'EZRSS', 'ezrss_ratio', '')
 
         TVTORRENTS = bool(check_setting_int(CFG, 'TVTORRENTS', 'tvtorrents', 0))
         TVTORRENTS_DIGEST = check_setting_str(CFG, 'TVTORRENTS', 'tvtorrents_digest', '')
         TVTORRENTS_HASH = check_setting_str(CFG, 'TVTORRENTS', 'tvtorrents_hash', '')
+        TVTORRENTS_RATIO = check_setting_str(CFG, 'TVTORRENTS', 'tvtorrents_ratio', '')
         TVTORRENTS_OPTIONS = check_setting_str(CFG, 'TVTORRENTS', 'tvtorrents_options', '')
 
         BTN = bool(check_setting_int(CFG, 'BTN', 'btn', 0))
         BTN_API_KEY = check_setting_str(CFG, 'BTN', 'btn_api_key', '')
+        BTN_RATIO = check_setting_str(CFG, 'BTN', 'btn_ratio', '')
         BTN_OPTIONS = check_setting_str(CFG, 'BTN', 'btn_options', '')
 
         THEPIRATEBAY = bool(check_setting_int(CFG, 'THEPIRATEBAY', 'thepiratebay', 1))
+        THEPIRATEBAY_RATIO = check_setting_str(CFG, 'THEPIRATEBAY', 'thepiratebay_ratio', '')
         THEPIRATEBAY_TRUSTED = bool(check_setting_int(CFG, 'THEPIRATEBAY', 'thepiratebay_trusted', 1))
         THEPIRATEBAY_PROXY = bool(check_setting_int(CFG, 'THEPIRATEBAY', 'thepiratebay_proxy', 0))
         THEPIRATEBAY_PROXY_URL = check_setting_str(CFG, 'THEPIRATEBAY', 'thepiratebay_proxy_url', '')
@@ -676,50 +696,60 @@ def initialize(consoleLogging=True):
         TORRENTLEECH = bool(check_setting_int(CFG, 'TORRENTLEECH', 'torrentleech', 0))
         TORRENTLEECH_USERNAME = check_setting_str(CFG, 'TORRENTLEECH', 'torrentleech_username', '')
         TORRENTLEECH_PASSWORD = check_setting_str(CFG, 'TORRENTLEECH', 'torrentleech_password', '')
+        TORRENTLEECH_RATIO = check_setting_str(CFG, 'TORRENTLEECH', 'torrentleech_ratio', '')
         TORRENTLEECH_OPTIONS = check_setting_str(CFG, 'TORRENTLEECH', 'torrentleech_options', '')
 
         IPTORRENTS = bool(check_setting_int(CFG, 'IPTORRENTS', 'iptorrents', 0))
         IPTORRENTS_USERNAME = check_setting_str(CFG, 'IPTORRENTS', 'iptorrents_username', '')
         IPTORRENTS_PASSWORD = check_setting_str(CFG, 'IPTORRENTS', 'iptorrents_password', '')
+        IPTORRENTS_RATIO = check_setting_str(CFG, 'IPTORRENTS', 'iptorrents_ratio', '')
         IPTORRENTS_FREELEECH = bool(check_setting_int(CFG, 'IPTORRENTS', 'iptorrents_freeleech', 0))
         IPTORRENTS_OPTIONS = check_setting_str(CFG, 'IPTORRENTS', 'iptorrents_options', '')
 
         NEXTGEN = bool(check_setting_int(CFG, 'NEXTGEN', 'nextgen', 0))
         NEXTGEN_USERNAME = check_setting_str(CFG, 'NEXTGEN', 'nextgen_username', '')
         NEXTGEN_PASSWORD = check_setting_str(CFG, 'NEXTGEN', 'nextgen_password', '')
+        NEXTGEN_RATIO = check_setting_str(CFG, 'NEXTGEN', 'nextgen_ratio', '')
         NEXTGEN_OPTIONS = check_setting_str(CFG, 'NEXTGEN', 'nextgen_options', '')
 
         KAT = bool(check_setting_int(CFG, 'KAT', 'kat', 0))
+        KAT_RATIO = check_setting_str(CFG, 'KAT', 'kat_ratio', '')
         KAT_VERIFIED = bool(check_setting_int(CFG, 'KAT', 'kat_verified', 1))
         KAT_OPTIONS = check_setting_str(CFG, 'KAT', 'kat_options', '')
 
         PUBLICHD = bool(check_setting_int(CFG, 'PUBLICHD', 'publichd', 0))
+        PUBLICHD_RATIO = check_setting_str(CFG, 'PUBLICHD', 'publichd_ratio', '')
         PUBLICHD_OPTIONS = check_setting_str(CFG, 'PUBLICHD', 'publichd_options', '')
 
         SCC = bool(check_setting_int(CFG, 'SCC', 'scc', 0))
         SCC_USERNAME = check_setting_str(CFG, 'SCC', 'scc_username', '')
         SCC_PASSWORD = check_setting_str(CFG, 'SCC', 'scc_password', '')
+        SCC_RATIO = check_setting_str(CFG, 'SCC', 'scc_ratio', '')
         SCC_OPTIONS = check_setting_str(CFG, 'SCC', 'scc_options', '')
 
         HDTORRENTS = bool(check_setting_int(CFG, 'HDTORRENTS', 'hdtorrents', 0))
         HDTORRENTS_USERNAME = check_setting_str(CFG, 'HDTORRENTS', 'hdtorrents_username', '')
         HDTORRENTS_PASSWORD = check_setting_str(CFG, 'HDTORRENTS', 'hdtorrents_password', '')
+        HDTORRENTS_RATIO = check_setting_str(CFG, 'HDTORRENTS', 'hdtorrents_ratio', '')
         HDTORRENTS_OPTIONS = check_setting_str(CFG, 'HDTORRENTS', 'hdtorrents_options', '')
 
         TORRENTDAY = bool(check_setting_int(CFG, 'TORRENTDAY', 'torrentday', 0))
         TORRENTDAY_USERNAME = check_setting_str(CFG, 'TORRENTDAY', 'torrentday_username', '')
         TORRENTDAY_PASSWORD = check_setting_str(CFG, 'TORRENTDAY', 'torrentday_password', '')
+        TORRENTDAY_RATIO = check_setting_str(CFG, 'TORRENTDAY', 'torrentday_ratio', '')
         TORRENTDAY_FREELEECH = bool(check_setting_int(CFG, 'TORRENTDAY', 'torrentday_freeleech', 0))
         TORRENTDAY_OPTIONS = check_setting_str(CFG, 'TORRENTDAY', 'torrentday_options', '')
 
         HDBITS = bool(check_setting_int(CFG, 'HDBITS', 'hdbits', 0))
         HDBITS_USERNAME = check_setting_str(CFG, 'HDBITS', 'hdbits_username', '')
         HDBITS_PASSKEY = check_setting_str(CFG, 'HDBITS', 'hdbits_passkey', '')
+        HDBITS_RATIO = check_setting_str(CFG, 'HDBITS', 'hdbits_ratio', '')
         HDBITS_OPTIONS = check_setting_str(CFG, 'HDBITS', 'hdbits_options', '')
 
         SPEEDCD = bool(check_setting_int(CFG, 'SPEEDCD', 'speedcd', 0))
         SPEEDCD_USERNAME = check_setting_str(CFG, 'SPEEDCD', 'speedcd_username', '')
         SPEEDCD_PASSWORD = check_setting_str(CFG, 'SPEEDCD', 'speedcd_password', '')
+        SPEEDCD_RATIO = check_setting_str(CFG, 'SPEEDCD', 'speedcd_ratio', '')
         SPEEDCD_FREELEECH = bool(check_setting_int(CFG, 'SPEEDCD', 'speedcd_freeleech', 0))
 
         NZBS = bool(check_setting_int(CFG, 'NZBs', 'nzbs', 0))
@@ -1366,20 +1396,24 @@ def save_config():
 
     new_config['EZRSS'] = {}
     new_config['EZRSS']['ezrss'] = int(EZRSS)
+    new_config['EZRSS']['ezrss_ratio'] = EZRSS_RATIO
 
     new_config['TVTORRENTS'] = {}
     new_config['TVTORRENTS']['tvtorrents'] = int(TVTORRENTS)
     new_config['TVTORRENTS']['tvtorrents_digest'] = TVTORRENTS_DIGEST
     new_config['TVTORRENTS']['tvtorrents_hash'] = TVTORRENTS_HASH
+    new_config['TVTORRENTS']['tvtorrents_ratio'] = TVTORRENTS_RATIO
     new_config['TVTORRENTS']['tvtorrents_options'] = TVTORRENTS_OPTIONS
 
     new_config['BTN'] = {}
     new_config['BTN']['btn'] = int(BTN)
     new_config['BTN']['btn_api_key'] = BTN_API_KEY
+    new_config['BTN']['btn_ratio'] = BTN_RATIO
     new_config['BTN']['btn_options'] = BTN_OPTIONS
 
     new_config['THEPIRATEBAY'] = {}
     new_config['THEPIRATEBAY']['thepiratebay'] = int(THEPIRATEBAY)
+    new_config['THEPIRATEBAY']['thepiratebay_ratio'] = THEPIRATEBAY_RATIO
     new_config['THEPIRATEBAY']['thepiratebay_trusted'] = int(THEPIRATEBAY_TRUSTED)
     new_config['THEPIRATEBAY']['thepiratebay_proxy'] = int(THEPIRATEBAY_PROXY)
     new_config['THEPIRATEBAY']['thepiratebay_proxy_url'] = THEPIRATEBAY_PROXY_URL
@@ -1390,12 +1424,14 @@ def save_config():
     new_config['TORRENTLEECH']['torrentleech'] = int(TORRENTLEECH)
     new_config['TORRENTLEECH']['torrentleech_username'] = TORRENTLEECH_USERNAME
     new_config['TORRENTLEECH']['torrentleech_password'] = helpers.encrypt(TORRENTLEECH_PASSWORD, ENCRYPTION_VERSION)
+    new_config['TORRENTLEECH']['torrentleech_ratio'] = TORRENTLEECH_RATIO
     new_config['TORRENTLEECH']['torrentleech_options'] = TORRENTLEECH_OPTIONS
 
     new_config['IPTORRENTS'] = {}
     new_config['IPTORRENTS']['iptorrents'] = int(IPTORRENTS)
     new_config['IPTORRENTS']['iptorrents_username'] = IPTORRENTS_USERNAME
     new_config['IPTORRENTS']['iptorrents_password'] = helpers.encrypt(IPTORRENTS_PASSWORD, ENCRYPTION_VERSION)
+    new_config['IPTORRENTS']['iptorrents_ratio'] = IPTORRENTS_RATIO
     new_config['IPTORRENTS']['iptorrents_freeleech'] = int(IPTORRENTS_FREELEECH)
     new_config['IPTORRENTS']['iptorrents_options'] = IPTORRENTS_OPTIONS
 
@@ -1403,33 +1439,39 @@ def save_config():
     new_config['NEXTGEN']['nextgen'] = int(NEXTGEN)
     new_config['NEXTGEN']['nextgen_username'] = NEXTGEN_USERNAME
     new_config['NEXTGEN']['nextgen_password'] = helpers.encrypt(NEXTGEN_PASSWORD, ENCRYPTION_VERSION)
+    new_config['NEXTGEN']['nextgen_ratio'] = NEXTGEN_RATIO
     new_config['NEXTGEN']['nextgen_options'] = NEXTGEN_OPTIONS
 
     new_config['KAT'] = {}
     new_config['KAT']['kat'] = int(KAT)
+    new_config['KAT']['kat_ratio'] = KAT_RATIO
     new_config['KAT']['kat_verified'] = int(KAT_VERIFIED)
     new_config['KAT']['kat_options'] = KAT_OPTIONS
 
     new_config['PUBLICHD'] = {}
     new_config['PUBLICHD']['publichd'] = int(PUBLICHD)
+    new_config['PUBLICHD']['publichd_ratio'] = PUBLICHD_RATIO
     new_config['PUBLICHD']['publichd_options'] = PUBLICHD_OPTIONS
 
     new_config['SCC'] = {}
     new_config['SCC']['scc'] = int(SCC)
     new_config['SCC']['scc_username'] = SCC_USERNAME
     new_config['SCC']['scc_password'] = helpers.encrypt(SCC_PASSWORD, ENCRYPTION_VERSION)
+    new_config['SCC']['scc_ratio'] = SCC_RATIO
     new_config['SCC']['scc_options'] = SCC_OPTIONS
 
     new_config['HDTORRENTS'] = {}
     new_config['HDTORRENTS']['hdtorrents'] = int(HDTORRENTS)
     new_config['HDTORRENTS']['hdtorrents_username'] = HDTORRENTS_USERNAME
     new_config['HDTORRENTS']['hdtorrents_password'] = helpers.encrypt(HDTORRENTS_PASSWORD, ENCRYPTION_VERSION)
+    new_config['HDTORRENTS']['hdtorrents_ratio'] = HDTORRENTS_RATIO
     new_config['HDTORRENTS']['hdtorrents_options'] = HDTORRENTS_OPTIONS
 
     new_config['TORRENTDAY'] = {}
     new_config['TORRENTDAY']['torrentday'] = int(TORRENTDAY)
     new_config['TORRENTDAY']['torrentday_username'] = TORRENTDAY_USERNAME
     new_config['TORRENTDAY']['torrentday_password'] = helpers.encrypt(TORRENTDAY_PASSWORD, ENCRYPTION_VERSION)
+    new_config['TORRENTDAY']['torrentday_ratio'] = TORRENTDAY_RATIO
     new_config['TORRENTDAY']['torrentday_freeleech'] = int(TORRENTDAY_FREELEECH)
     new_config['TORRENTDAY']['torrentday_options'] = TORRENTDAY_OPTIONS
 
@@ -1437,12 +1479,14 @@ def save_config():
     new_config['HDBITS']['hdbits'] = int(HDBITS)
     new_config['HDBITS']['hdbits_username'] = HDBITS_USERNAME
     new_config['HDBITS']['hdbits_passkey'] = HDBITS_PASSKEY
+    new_config['HDBITS']['hdbits_ratio'] = HDBITS_RATIO
     new_config['HDBITS']['hdbits_options'] = HDBITS_OPTIONS
 
     new_config['SPEEDCD'] = {}
     new_config['SPEEDCD']['speedcd'] = int(SPEEDCD)
     new_config['SPEEDCD']['speedcd_username'] = SPEEDCD_USERNAME
     new_config['SPEEDCD']['speedcd_password'] = helpers.encrypt(SPEEDCD_PASSWORD, ENCRYPTION_VERSION)
+    new_config['SPEEDCD']['speedcd_ratio'] = SPEEDCD_RATIO
     new_config['SPEEDCD']['speedcd_freeleech'] = int(SPEEDCD_FREELEECH)
 
     new_config['NZBs'] = {}

--- a/sickbeard/clients/transmission.py
+++ b/sickbeard/clients/transmission.py
@@ -21,6 +21,7 @@ import json
 from base64 import b64encode
 
 import sickbeard
+from sickbeard import logger
 from sickbeard.clients.generic import GenericClient
 
 
@@ -79,17 +80,29 @@ class TransmissionAPI(GenericClient):
 
     def _set_torrent_ratio(self, result):
 
+        ratio = ''
+        if result.ratio:
+            ratio = result.ratio
+        elif sickbeard.TORRENT_RATIO:
+            ratio = sickbeard.TORRENT_RATIO
+
+        try:
+            float(ratio)
+        except ValueError:
+            logger.log(self.name + u': Invalid Ratio. "' + ratio + u'" is not a number', logger.ERROR)
+            return False
+
         torrent_id = self._get_torrent_hash(result)
 
-        if sickbeard.TORRENT_RATIO == '':
+        if ratio == '':
             # Use global settings
             ratio = None
             mode = 0
-        elif float(sickbeard.TORRENT_RATIO) == 0:
+        elif float(ratio) == 0:
             ratio = 0
             mode = 2
-        elif float(sickbeard.TORRENT_RATIO) > 0:
-            ratio = float(sickbeard.TORRENT_RATIO)
+        elif float(ratio) > 0:
+            ratio = float(ratio)
             mode = 1  # Stop seeding at seedRatioLimit
 
         arguments = {'ids': [torrent_id],

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -293,6 +293,9 @@ class BTNProvider(generic.TorrentProvider):
 
         return results
 
+    def seedRatio(self):
+        return sickbeard.BTN_RATIO
+
 
 class BTNCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/ezrss.py
+++ b/sickbeard/providers/ezrss.py
@@ -156,6 +156,9 @@ class EZRSSProvider(generic.TorrentProvider):
             return match.group(1)
         return None
 
+    def seedRatio(self):
+        return sickbeard.EZRSS_RATIO
+
 
 class EZRSSCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -389,6 +389,13 @@ class GenericProvider:
 
         return [classes.Proper(x['name'], x['url'], datetime.datetime.fromtimestamp(x['time'])) for x in results]
 
+    def seedRatio(self):
+        '''
+        Provider should override this value if custom seed ratio enabled
+        It should return the value of the provider seed ratio
+        '''
+        return ''
+
 
 class NZBProvider(GenericProvider):
     def __init__(self, name):

--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -180,6 +180,9 @@ class HDBitsProvider(generic.TorrentProvider):
 
         return json.dumps(post_data)
 
+    def seedRatio(self):
+        return sickbeard.HDBITS_RATIO
+
 
 class HDBitsCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -317,6 +317,9 @@ class HDTorrentsProvider(generic.TorrentProvider):
 
         return results
 
+    def seedRatio(self):
+        return sickbeard.HDTORRENTS_RATIO
+
 
 class HDTorrentsCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -265,6 +265,9 @@ class IPTorrentsProvider(generic.TorrentProvider):
 
         return results
 
+    def seedRatio(self):
+        return sickbeard.IPTORRENTS_RATIO
+
 
 class IPTorrentsCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -392,6 +392,8 @@ class KATProvider(generic.TorrentProvider):
 
         return results
 
+    def seedRatio(self):
+        return sickbeard.KAT_RATIO
 
 class KATCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/nextgen.py
+++ b/sickbeard/providers/nextgen.py
@@ -313,6 +313,9 @@ class NextGenProvider(generic.TorrentProvider):
 
         return results
 
+    def seedRatio(self):
+        return sickbeard.NEXTGEN_RATIO
+
 
 class NextGenCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/publichd.py
+++ b/sickbeard/providers/publichd.py
@@ -286,6 +286,9 @@ class PublicHDProvider(generic.TorrentProvider):
 
         return results
 
+    def seedRatio(self):
+        return sickbeard.PUBLICHD_RATIO
+
 
 class PublicHDCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -291,6 +291,9 @@ class SCCProvider(generic.TorrentProvider):
 
         return results
 
+    def seedRatio(self):
+        return sickbeard.SCC_RATIO
+
 
 class SCCCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -244,6 +244,9 @@ class SpeedCDProvider(generic.TorrentProvider):
 
         return results
 
+    def seedRatio(self):
+        return sickbeard.SPEEDCD_RATIO
+
 
 class SpeedCDCache(tvcache.TVCache):
 

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -384,6 +384,9 @@ class ThePirateBayProvider(generic.TorrentProvider):
 
         return results
 
+    def seedRatio(self):
+        return sickbeard.THEPIRATEBAY_RATIO
+
 
 class ThePirateBayCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -263,6 +263,9 @@ class TorrentDayProvider(generic.TorrentProvider):
 
         return results
 
+    def seedRatio(self):
+        return sickbeard.TORRENTDAY_RATIO
+
 
 class TorrentDayCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -264,6 +264,9 @@ class TorrentLeechProvider(generic.TorrentProvider):
 
         return results
 
+    def seedRatio(self):
+        return sickbeard.TORRENTLEECH_RATIO
+
 
 class TorrentLeechCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/tvtorrents.py
+++ b/sickbeard/providers/tvtorrents.py
@@ -69,6 +69,9 @@ class TvTorrentsProvider(generic.TorrentProvider):
 
         return True
 
+    def seedRatio(self):
+        return sickbeard.TVTORRENTS_RATIO
+
 
 class TvTorrentsCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -139,6 +139,8 @@ def snatchEpisode(result, endStatus=SNATCHED):
         if sickbeard.TORRENT_METHOD == "blackhole":
             dlResult = _downloadResult(result)
         else:
+            #Sets per provider seed ratio
+            result.ratio = result.provider.seedRatio()
             result.content = result.provider.getURL(result.url) if not result.url.startswith('magnet') else None
             client = clients.getClientIstance(sickbeard.TORRENT_METHOD)()
             dlResult = client.sendTORRENT(result)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1403,19 +1403,21 @@ class ConfigProviders:
     @cherrypy.expose
     def saveProviders(self, newznab_string='', torrentrss_string='',
                       omgwtfnzbs_username=None, omgwtfnzbs_apikey=None,
-                      tvtorrents_digest=None, tvtorrents_hash=None,
-                      btn_api_key=None,
-                      thepiratebay_trusted=None, thepiratebay_proxy=None, thepiratebay_proxy_url=None,
-                      torrentleech_username=None, torrentleech_password=None,
-                      iptorrents_username=None, iptorrents_password=None, iptorrents_freeleech=None,
-                      kat_trusted=None, kat_verified=None,
-                      scc_username=None, scc_password=None,
-                      hdtorrents_username=None, hdtorrents_password=None,
-                      torrentday_username=None, torrentday_password=None, torrentday_freeleech=None,
-                      hdbits_username=None, hdbits_passkey=None,
-                      nextgen_username=None, nextgen_password=None,
+                      ezrss_ratio=None,
+                      tvtorrents_digest=None, tvtorrents_hash=None, tvtorrents_ratio=None,
+                      btn_api_key=None, btn_ratio=None,
+                      thepiratebay_ratio=None, thepiratebay_trusted=None, thepiratebay_proxy=None, thepiratebay_proxy_url=None,
+                      torrentleech_username=None, torrentleech_password=None, torrentleech_ratio=None,
+                      iptorrents_username=None, iptorrents_password=None, iptorrents_ratio=None, iptorrents_freeleech=None,
+                      kat_trusted=None, kat_ratio=None, kat_verified=None,
+                      publichd_ratio=None,
+                      scc_username=None, scc_password=None, scc_ratio=None,
+                      hdtorrents_username=None, hdtorrents_password=None, hdtorrents_ratio=None,
+                      torrentday_username=None, torrentday_password=None, torrentday_ratio=None, torrentday_freeleech=None,
+                      hdbits_username=None, hdbits_passkey=None, hdbits_ratio=None,
+                      nextgen_username=None, nextgen_password=None, nextgen_ratio=None,
                       newzbin_username=None, newzbin_password=None,
-                      speedcd_username=None, speedcd_password=None, speedcd_freeleech=None,
+                      speedcd_username=None, speedcd_password=None, speedcd_ratio=None, speedcd_freeleech=None,
                       provider_order=None):
 
         results = []
@@ -1556,11 +1558,16 @@ class ConfigProviders:
             else:
                 logger.log(u"don't know what " + curProvider + " is, skipping")
 
+        sickbeard.EZRSS_RATIO = ezrss_ratio
+
         sickbeard.TVTORRENTS_DIGEST = tvtorrents_digest.strip()
         sickbeard.TVTORRENTS_HASH = tvtorrents_hash.strip()
+        sickbeard.TVTORRENTS_RATIO = tvtorrents_ratio
 
         sickbeard.BTN_API_KEY = btn_api_key.strip()
+        sickbeard.BTN_RATIO = btn_ratio
 
+        sickbeard.THEPIRATEBAY_RATIO = thepiratebay_ratio
         sickbeard.THEPIRATEBAY_TRUSTED = config.checkbox_to_value(thepiratebay_trusted)
 
         thepiratebay_proxy = config.checkbox_to_value(thepiratebay_proxy)
@@ -1573,38 +1580,48 @@ class ConfigProviders:
 
         sickbeard.TORRENTLEECH_USERNAME = torrentleech_username
         sickbeard.TORRENTLEECH_PASSWORD = torrentleech_password
+        sickbeard.TORRENTLEECH_RATIO = torrentleech_ratio
 
         sickbeard.IPTORRENTS_USERNAME = iptorrents_username.strip()
         sickbeard.IPTORRENTS_PASSWORD = iptorrents_password.strip()
+        sickbeard.IPTORRENTS_RATIO = iptorrents_ratio
 
         sickbeard.IPTORRENTS_FREELEECH = config.checkbox_to_value(iptorrents_freeleech)
 
         sickbeard.KAT_TRUSTED = config.checkbox_to_value(kat_trusted)
-
+        sickbeard.KAT_RATIO = kat_ratio
         sickbeard.KAT_VERIFIED = config.checkbox_to_value(kat_verified)
+        
+        sickbeard.PUBLICHD_RATIO = publichd_ratio
 
         sickbeard.TORRENTDAY_USERNAME = torrentday_username.strip()
         sickbeard.TORRENTDAY_PASSWORD = torrentday_password.strip()
+        sickbeard.TORRENTDAY_RATIO = torrentday_ratio
 
         sickbeard.TORRENTDAY_FREELEECH = config.checkbox_to_value(torrentday_freeleech)
 
         sickbeard.SCC_USERNAME = scc_username.strip()
         sickbeard.SCC_PASSWORD = scc_password.strip()
+        sickbeard.SCC_RATIO = scc_ratio
 
         sickbeard.HDTORRENTS_USERNAME = hdtorrents_username.strip()
         sickbeard.HDTORRENTS_PASSWORD = hdtorrents_password.strip()
+        sickbeard.HDTORRENTS_RATIO = hdtorrents_ratio
 
         sickbeard.HDBITS_USERNAME = hdbits_username.strip()
         sickbeard.HDBITS_PASSKEY = hdbits_passkey.strip()
+        sickbeard.HDBITS_RATIO = hdbits_ratio
 
         sickbeard.OMGWTFNZBS_USERNAME = omgwtfnzbs_username.strip()
         sickbeard.OMGWTFNZBS_APIKEY = omgwtfnzbs_apikey.strip()
 
         sickbeard.NEXTGEN_USERNAME = nextgen_username.strip()
         sickbeard.NEXTGEN_PASSWORD = nextgen_password.strip()
+        sickbeard.NEXTGEN_RATIO = nextgen_ratio
 
         sickbeard.SPEEDCD_USERNAME = speedcd_username.strip()
         sickbeard.SPEEDCD_PASSWORD = speedcd_password.strip()
+        sickbeard.SPEEDCD_RATIO = speedcd_ratio
         sickbeard.SPEEDCD_FREELEECH = config.checkbox_to_value(speedcd_freeleech)
 
         sickbeard.NEWZNAB_DATA = '!!!'.join([x.configStr() for x in sickbeard.newznabProviderList])


### PR DESCRIPTION
Adds Per Provider Seed Ratio for all torrent providers apart from users
custom rss feeds (I will add this at a later date).
Support for utorrent, transmission and deluge is included.

Some minor bug fixes are also included:
Fixes deluge hang when adding a label with spaces

The deluge client cannot handle labels with spaces. It currently causes
a number of timeout errors if you try to add a label with a space.
This commit adds a code to reject labels with spaces in and also adds a
warning box in the deluge torrent page warning users not to create
labels with spaces in them i.e. "tv shows" is not allowed but "tvshows"
is fine.

Since rtorrent seed ratio has been disabled in sickbeard for a long time
(the code is hashed out in the master branch) I have hidden the ratio
setting box in the rtorrent config page until it gets fixed.
There is apparently a bug in rtorrent that causes random torrents to enter
a pause state when setting the seed ratio.
I have also added a method to each torrent client to capture converting
to float errors when setting the seed ratio.
