### PR TITLE
Debian style LSB init script

### DIFF
--- a/init.debian
+++ b/init.debian
@@ -1,0 +1,160 @@
+#!/bin/sh
+#
+### BEGIN INIT INFO
+# Provides:          sickbeard
+# Required-Start:    $local_fs $network $remote_fs
+# Required-Stop:     $local_fs $network $remote_fs
+# Should-Start:      $NetworkManager
+# Should-Stop:       $NetworkManager
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: starts instance of SickBeard
+# Description:       starts instance of SickBeard using start-stop-daemon
+### END INIT INFO
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
+. /lib/lsb/init-functions
+
+# Source SickBeard configuration
+if [ -f /etc/default/sickbeard ]; then
+    . /etc/default/sickbeard
+else
+    [ "${VERBOSE}" != no ] && echo "/etc/default/sickbeard not found. Using default settings.";
+fi
+
+## Don't set -e
+## Don't edit this file!
+## Edit user configuation in /etc/default/sickbeard to change
+##
+## SB_USER=         #$RUN_AS, username to run sickbeard under, the default is sickbeard
+## SB_GROUP=        #$RUN_GROUP, group to run sickbeard under, the default is sickbeard
+## SB_HOME=         #$APP_PATH, the location of SickBeard.py, the default is /opt/sickbeard
+## SB_DATA=         #$DATA_DIR, the location of sickbeard.db, cache, logs, the default is /opt/sickbeard
+## SB_PIDFILE=      #$PID_FILE, the location of sickbeard.pid, the default is /var/run/sickbeard/sickbeard.pid
+## PYTHON_BIN=      #$DAEMON, the location of the python binary, the default is /usr/bin/python
+## SB_OPTS=         #$EXTRA_DAEMON_OPTS, extra cli option for sickbeard, i.e. " --config=/home/sickbeard/config.ini"
+## SSD_OPTS=        #$EXTRA_SSD_OPTS, extra start-stop-daemon option like " --group=users"
+##
+## EXAMPLE if want to run as different user
+## add SB_USER=username to /etc/default/sickbeard
+## otherwise default sickbeard is used
+
+# Script name
+NAME=$(basename "$0")
+
+# App name
+DESC=SickBeard
+
+## The defaults
+# Run as username 
+RUN_AS=${SB_USER-sickbeard}
+
+# Run as group
+RUN_GROUP=${SB_GROUP-sickbeard}
+
+# Path to app SB_HOME=path_to_app_SickBeard.py
+APP_PATH=${SB_HOME-/opt/sickbeard}
+
+# Data directory where sickbeard.db, cache and logs are stored
+DATA_DIR=${SB_DATA-/opt/sickbeard}
+
+# Path to store PID file
+PID_FILE=${SB_PIDFILE-/var/run/sickbeard/sickbeard.pid}
+
+# path to python bin
+DAEMON=${PYTHON_BIN-/usr/bin/python}
+
+# Extra daemon option like: SB_OPTS=" --config=/home/sickbeard/config.ini"
+EXTRA_DAEMON_OPTS=${SB_OPTS-}
+
+# Extra start-stop-daemon option like START_OPTS=" --group=users"
+EXTRA_SSD_OPTS=${SSD_OPTS-}
+##
+
+PID_PATH=$(dirname $PID_FILE)
+DAEMON_OPTS=" SickBeard.py -q --daemon --nolaunch --pidfile=${PID_FILE} --datadir=${DATA_DIR} ${EXTRA_DAEMON_OPTS}"
+
+##
+
+test -x $DAEMON || exit 0
+
+# Create PID directory if not exist and ensure the SickBeard user can write to it
+if [ ! -d $PID_PATH ]; then
+    mkdir -p $PID_PATH
+    chown $RUN_AS $PID_PATH
+fi
+
+if [ ! -d $DATA_DIR ]; then
+    mkdir -p $DATA_DIR
+    chown $RUN_AS $DATA_DIR
+fi
+
+if [ -e $PID_FILE ]; then
+    PID=`cat $PID_FILE`
+    if ! kill -0 $PID > /dev/null 2>&1; then
+        [ "$VERBOSE" != no ] && echo "Removing stale $PID_FILE"
+        rm -f $PID_FILE
+    fi
+fi
+
+start_sickbeard() {
+    [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+    start-stop-daemon -d $APP_PATH -c $RUN_AS --group=${RUN_GROUP} $EXTRA_SSD_OPTS --start --quiet --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS 
+    RETVAL="$?"
+    case "${RETVAL}" in
+        # Service was started or was running already
+        0|1) [ "${VERBOSE}" != no ] && log_end_msg 0 ;;
+        # Service couldn't be started
+        2) [ "${VERBOSE}" != no ] && log_end_msg 1 ;;
+    esac
+    [ "${RETVAL}" = 2 ] && return 2
+    return 0
+}
+
+stop_sickbeard() {
+    [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+    start-stop-daemon --stop --pidfile $PID_FILE --quiet --retry TERM/30/KILL/5
+    RETVAL="$?"
+    case "${RETVAL}" in
+        # Service was stopped or wasn't running
+        0|1) [ "${VERBOSE}" != no ] && log_end_msg 0 ;;
+        # Service couldn't be stopped
+        2) [ "${VERBOSE}" != no ] && log_end_msg 1 ;;
+    esac
+    [ "${RETVAL}" = 2 ] && return 2
+    [ -f "${PID_FILE}" ] && rm -f ${PID_FILE}
+    return 0 
+}
+
+case "$1" in
+    start)
+        start_sickbeard
+        exit $?
+        ;;
+    stop)
+        stop_sickbeard
+        exit $?
+        ;;
+
+    restart|force-reload)
+        stop_sickbeard
+        sleep 2
+        start_sickbeard
+        return $?
+        ;;
+    status)
+        status_of_proc -p "$PID_FILE" "$DAEMON" "$DESC"
+        exit 0
+        ;;
+    *)
+        N=/etc/init.d/$NAME
+        echo "Usage: $N {start|stop|restart|force-reload}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
Added a Debian LSB script, which uses the /etc/default/rcS VERBOSE variable to show/hide messages.

Also added the SB_GROUP option support in /etc/default/sickbeard / RUN_GROUP variable for those who want a separate variable for controlling the --group= feature from start-stop-daemon.

Based on the init.ubuntu file.
