### PR TITLE
Fixes Invalid ratio error when ratio is not set for transmission

### DIFF
--- a/sickbeard/clients/transmission.py
+++ b/sickbeard/clients/transmission.py
@@ -85,12 +85,12 @@ class TransmissionAPI(GenericClient):
             ratio = result.ratio
         elif sickbeard.TORRENT_RATIO:
             ratio = sickbeard.TORRENT_RATIO
-
-        try:
-            float(ratio)
-        except ValueError:
-            logger.log(self.name + u': Invalid Ratio. "' + ratio + u'" is not a number', logger.ERROR)
-            return False
+        if ratio:
+            try:
+                float(ratio)
+            except ValueError:
+                logger.log(self.name + u': Invalid Ratio. "' + ratio + u'" is not a number', logger.ERROR)
+                return False
 
         torrent_id = self._get_torrent_hash(result)
 


### PR DESCRIPTION
I would also recommend undoing 7673cd5cc9d8e797a5b83cf956ede4eaae3deb7e for the time being
as some of the client scripts have code dependent on the input being a string.
