### PR TITLE
fix typo in xbmc notifier

### DIFF
--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -543,7 +543,7 @@ class XBMCNotifier:
                         return True
                 else:
                     if sickbeard.XBMC_ALWAYS_ON:
-                        logger.log(u"Failed to detect XBMC version for '" + curHost + "', check configuration and try again.", logger.ERROR)
+                        logger.log(u"Failed to detect XBMC version for '" + host + "', check configuration and try again.", logger.ERROR)
                     result = result + 1
 
             # needed for the 'update xbmc' submenu command


### PR DESCRIPTION
fixing a typo introduced from backporting the xbmc always on option.
