### PR TITLE
Fix Renaming issue for not PROPER release generating two dot in filename

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1904,6 +1904,9 @@ class TVEpisode(object):
             result_name = result_name.replace('%rg', 'sickbeard')
             logger.log(u"Episode has no release name, replacing it with a generic one: " + result_name, logger.DEBUG)
 
+        if not replace_map['%RT']:
+            result_name = re.sub('([ _.-]*)%RT([ _.-]*)', r'\2', result_name)
+
         # split off ep name part only
         name_groups = re.split(r'[\\/]', result_name)
 


### PR DESCRIPTION
Fix renamer error for not PROPER release.

generating two dot in filename when using pattern like : 

```
Season %0S/%S.N.S%0SE%0E.%RT.%Q.N-%RG
Season 02/Show.Name.S02E03.PROPER.HD.TV-RLSGROUP.ext
```
