### PR TITLE
Fix for alterate scene names in theme

### DIFF
--- a/gui/slick/interfaces/default/displayShow.tmpl
+++ b/gui/slick/interfaces/default/displayShow.tmpl
@@ -163,16 +163,6 @@
 #if $anyQualities + $bestQualities
     <tr><td class="showLegend">Archive First Match: </td><td><img src="$sbRoot/images/#if int($show.archive_firstmatch) == 1 then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
 #end if
-#if $all_scene_exceptions:
-	<tr>
-		<td class="showLegend">Alternate Scene Names:</td>
-		<td>
-			#for $one_exception in sorted($all_scene_exceptions)
-				$one_exception<br />
-			#end for
-		</td>
-	</tr>
-#end if
 </table>
 </td>
 </tr>


### PR DESCRIPTION
These alternate scene names where displayed double in the theme. They are showing on the left side and on the right side. I've chosen to remove it on the right side since it wasn't a very good fit. With this fix it doesn't screw up the theme anymore when there are several alternate scene names. 
