### PR TITLE
Display combined SR post processing outcome

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -150,6 +150,11 @@ def processDir(dirName, nzbName=None, process_method=None, force=False, is_prior
                     if processPath != sickbeard.TV_DOWNLOAD_DIR:
                         delete_dir(processPath)
 
+    if process_result:
+        returnStr += logHelper(u"Successfully processed")
+    else:
+        returnStr += logHelper(u"Problem(s) during processing", logger.WARNING)
+
     return returnStr
 
 


### PR DESCRIPTION
Output success if _all_ the many post processing actions are successful, otherwise indicate a problem occurred if one fails.

This outcome message is displayed in the SAB history UI and improves on the existing "deleting filex" message that only applies to the last action done during a multiple action batch. The "deleting" message is also confusing as its tense is in the present, or not yet complete.

before this change, the last output line is shown by sab ...
![Image of sab before #569](http://i.imgur.com/kjIRe6o.png)

after this change, the last line of output shows the overall post process outcome ...
![Image of sab after #569](http://i.imgur.com/SmySn85.png)
