### PR TITLE
Fix: Clicking on the label "Process backlog on startup" will no longer...

### DIFF
--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -119,7 +119,7 @@
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input type="checkbox" name="rssupdate_startup" id="backlog_startup" #if $sickbeard.RSSUPDATE_STARTUP == True then "checked=\"checked\"" else ""# />
+                            <input type="checkbox" name="rssupdate_startup" id="rssupdate_startup" #if $sickbeard.RSSUPDATE_STARTUP == True then "checked=\"checked\"" else ""# />
                             <label class="clearfix" for="rssupdate_startup">
                                 <span class="component title">RSS Cache Updates on startup</span>
                                 <span class="component-desc">Start RSS Cache updates upon startup of SickRage?</span>


### PR DESCRIPTION
...toggle the check-box of "RSS Cache Updates on startup".
