### PR TITLE
Remove redundant bestResult loop

### DIFF
--- a/sickbeard/dailysearcher.py
+++ b/sickbeard/dailysearcher.py
@@ -119,10 +119,6 @@ class DailySearcher():
 
                 # find the best result for the current episode
                 bestResult = None
-                for curResult in curFoundResults[curEp]:
-                    if not bestResult or bestResult.quality < curResult.quality:
-                        bestResult = curResult
-
                 bestResult = pickBestResult(curFoundResults[curEp], curEp.show)
 
                 # if all results were rejected move on to the next episode


### PR DESCRIPTION
The entire loop appears to be redundant and the bestResult is overwritten by pickBestResult immediately after
