### PR TITLE
Fixed infinite loop in lib/rtorrent

### DIFF
--- a/lib/rtorrent/__init__.py
+++ b/lib/rtorrent/__init__.py
@@ -216,7 +216,7 @@ class RTorrent:
             while i < MAX_RETRIES:
                 for torrent in self.get_torrents():
                     if torrent.info_hash != info_hash:
-                        break
+                        continue
                     time.sleep(1)
                     i += 1
 


### PR DESCRIPTION
This code works when there is only one torrent in rtorrent. As soon as there are multiple torrents, this just spins on the same torrent IF the first torrent isn't the one it is looking for. In general this function just brute forces the server as I expect it is written for a local SCGI endpoint.

(Side note, this was my second attempt to do this, since I didn't push to the correct branch properly when I started: https://github.com/echel0n/SickRage/pull/585)
