### PR TITLE
Changing filename in Show overview: Complete filename is on hover only, ...

### DIFF
--- a/gui/slick/css/default.css
+++ b/gui/slick/css/default.css
@@ -445,7 +445,8 @@ input:not(.btn){margin-right:6px;margin-top:5px;padding-top:4px;padding-bottom:4
 }
 
 .sickbeardTable td.filename {
-width: 30%;
+width: 10%;
+text-align: center;
 
 }
 

--- a/gui/slick/interfaces/default/displayShow.tmpl
+++ b/gui/slick/interfaces/default/displayShow.tmpl
@@ -278,7 +278,11 @@
 #elif $epLoc and (not $epLoc.lower().startswith($show._location.lower()) or not $show._location):
 	#set $epLoc = os.path.basename($epLoc)
 #end if
+#if $epLoc != "" and $epLoc != None:
+<a href="#" title="$epLoc">[details]</a>
+#else
 $epLoc
+#end if
 	</small>
     </td>
 #if $sickbeard.USE_SUBTITLES and $show.subtitles:


### PR DESCRIPTION
...to save space

This is a PR from the forums (https://sickrage.tv/forums/forum/main-category/feature-requests/866-filenames-on-show-pages-taking-up-a-lot-of-real-estate)
