### PR TITLE
Fixed setting ratio in Transmission

### DIFF
--- a/sickbeard/clients/transmission.py
+++ b/sickbeard/clients/transmission.py
@@ -88,10 +88,10 @@ class TransmissionAPI(GenericClient):
 
         mode = 0
         if ratio:
-            if float(ratio) == 0:
+            if float(ratio) == -1:
                 ratio = 0
                 mode = 2
-            elif float(ratio) > 0:
+            elif float(ratio) >= 0:
                 ratio = float(ratio)
                 mode = 1  # Stop seeding at seedRatioLimit
 


### PR DESCRIPTION
Matches the description in the torrent provider advanced settings:

Left blank defaults to client ratio default.
'-1' Seeds indefinitely
0 or greater seeds to and stops at the ratio (including stopping as soon as it downloads when set to 0)
