### PR TITLE
fix the web_root setting functionality broken in d73cc1c.

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -217,8 +217,6 @@ class IndexHandler(RequestHandler):
         self._transforms = []
         super(IndexHandler, self).redirect(sickbeard.WEB_ROOT + url, permanent, status)
 
-        super(IndexHandler, self).redirect(url, permanent, status)
-
     @asynchronous
     @gen.engine
     def get(self, *args, **kwargs):


### PR DESCRIPTION
A few web_root things were messed up in the tornado switchover. I believe I was able to fix the problems.
