### PR TITLE
Refactor scheduler and upstream ports.

### DIFF
--- a/sickbeard/scheduler.py
+++ b/sickbeard/scheduler.py
@@ -26,16 +26,14 @@ from sickbeard.exceptions import ex
 
 
 class Scheduler:
-    def __init__(self, action, cycleTime=datetime.timedelta(minutes=10), runImmediately=True,
-                 threadName="ScheduledThread", silent=False):
+    def __init__(self, action, cycleTime=datetime.timedelta(minutes=10), run_delay=datetime.timedelta(minutes=0),
+                 start_time=None, threadName="ScheduledThread", silent=True):
 
-        if runImmediately:
-            self.lastRun = datetime.datetime.fromordinal(1)
-        else:
-            self.lastRun = datetime.datetime.now()
+        self.lastRun = datetime.datetime.now() + run_delay - cycleTime
 
         self.action = action
         self.cycleTime = cycleTime
+        self.start_time = start_time
 
         self.thread = None
         self.threadName = threadName
@@ -64,10 +62,25 @@ class Scheduler:
 
         while True:
 
-            currentTime = datetime.datetime.now()
+            current_time = datetime.datetime.now()
+            should_run = False
 
-            if currentTime - self.lastRun > self.cycleTime:
-                self.lastRun = currentTime
+            # check if interval has passed
+            if current_time - self.lastRun >= self.cycleTime:
+                # check if wanting to start around certain time taking interval into account
+                if self.start_time:
+                    hour_diff = current_time.time().hour - self.start_time.hour
+                    if not hour_diff < 0 and hour_diff < self.cycleTime.seconds / 3600:
+                        should_run = True
+                    else:
+                        # set lastRun to only check start_time after another cycleTime
+                        self.lastRun = current_time
+                else:
+                    should_run = True
+
+            if should_run:
+                self.lastRun = current_time
+
                 try:
                     if not self.silent:
                         logger.log(u"Starting new thread: " + self.threadName, logger.DEBUG)

--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -31,26 +31,13 @@ from sickbeard import network_timezones
 from sickbeard import failed_history
 
 class ShowUpdater():
-    def __init__(self):
-        self.updateInterval = datetime.timedelta(hours=1)
 
     def run(self, force=False):
-
-        # update at 3 AM
-        run_updater_time = datetime.time(hour=3)
 
         update_datetime = datetime.datetime.now()
         update_date = update_datetime.date()
 
-        logger.log(u"Checking update interval", logger.DEBUG)
-
-        hour_diff = update_datetime.time().hour - run_updater_time.hour
-
-        # if it's less than an interval after the update time then do an update (or if we're forcing it)
-        if hour_diff >= 0 and hour_diff < self.updateInterval.seconds / 3600 or force:
-            logger.log(u"Doing full update on all shows")
-        else:
-            return
+        logger.log(u"Doing full update on all shows")
 
         # clean out cache directory, remove everything > 12 hours old
         if sickbeard.CACHE_DIR:
@@ -114,3 +101,5 @@ class ShowUpdater():
                 logger.log(u"Automatic update failed: " + ex(e), logger.ERROR)
 
         ui.ProgressIndicators.setIndicator('dailyUpdate', ui.QueueProgressIndicator("Daily Update", piList))
+
+        logger.log(u"Completed full update on all shows")

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1566,10 +1566,6 @@ class ConfigSearch(MainHandler):
         sickbeard.IGNORE_WORDS = ignore_words if ignore_words else ""
 
         sickbeard.DOWNLOAD_PROPERS = config.checkbox_to_value(download_propers)
-        if sickbeard.DOWNLOAD_PROPERS:
-            sickbeard.properFinderScheduler.silent = False
-        else:
-            sickbeard.properFinderScheduler.silent = True
         sickbeard.CHECK_PROPERS_INTERVAL = check_propers_interval
 
         sickbeard.ALLOW_HIGH_PRIORITY = config.checkbox_to_value(allow_high_priority)


### PR DESCRIPTION
Move start time check from properFinder and showUpdater into scheduler.
Add show how long to next propers search at end of each run.
Change proper finder and show updater to silent thread logging.
Change Scheduler runImmediately to run_delay.
