### PR TITLE
Removed Check as it slowed down daily search

### DIFF
--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -106,17 +106,17 @@ class NameParser(object):
         if not name:
             return
 
-        if not self.naming_pattern:
-            if not self.showObj:
-                for curShow in self.showList:
-                    if sickbeard.show_name_helpers.isGoodResult(name, curShow, False):
-                        self.showObj = curShow
-                        break
-
-                    time.sleep(cpu_presets[sickbeard.CPU_PRESET])
-
-            if not self.showObj:
-                return
+#        if not self.naming_pattern:
+#            if not self.showObj:
+#                for curShow in self.showList:
+#                    if sickbeard.show_name_helpers.isGoodResult(name, curShow, False):
+#                        self.showObj = curShow
+#                        break
+#
+#                    time.sleep(cpu_presets[sickbeard.CPU_PRESET])
+#
+#            if not self.showObj:
+#                return
 
         regexMode = self.ALL_REGEX
         if self.showObj and self.showObj.is_anime:
@@ -220,8 +220,8 @@ class NameParser(object):
                 result.release_group = match.group('release_group')
                 result.score += 1
 
-#            if not self.showObj:
-#                self.showObj = helpers.get_show_by_name(result.series_name, useIndexer=self.useIndexers)
+            if not self.showObj:
+                self.showObj = helpers.get_show_by_name(result.series_name, useIndexer=self.useIndexers)
 
             if self.showObj:
                 if self.showObj.air_by_date and result.air_date:


### PR DESCRIPTION
For every item in the RSS feed this check would search through every
item in your list of TV shows.  I currently have 287 shows, for 10 items
in an RSS feed this would produce 2870 database queries to lookup
scene_exceptions. This happened for Every provider.
