### PR TITLE
Fixed broken layout for anime black and whitelist

### DIFF
--- a/gui/slick/css/default.css
+++ b/gui/slick/css/default.css
@@ -888,6 +888,54 @@ td.tvShow a {
   -o-opacity: 1 !important;
   opacity: 1 !important;
 }
+
+/* Anime section for editShow */
+#Anime {
+    clear: both;
+    display: block ;
+    overflow-x: hidden; 
+    overflow-y: hidden;
+    padding-bottom: 10px;
+    padding-left: 20px;
+    padding-right: 0px;
+    padding-top: 10px;
+    font-size: 14px;
+}
+
+#Anime div.component-group-desc {
+    float: left;
+    width: 165px;
+}
+#Anime div.component-group-desc p {
+    color: #666666;
+    margin-bottom: 0.4em;
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: 0.4em;
+    width: 95%;
+}
+
+div.blackwhitelist{
+  float: left;
+  text-align: center;
+}
+div.blackwhitelist input {
+  margin: 5px 0px;
+}
+div.blackwhitelist.pool select {
+  min-width: 230px;
+}
+div.blackwhitelist.white select, div.blackwhitelist.black select {
+  min-width: 150px;
+}
+div.blackwhitelist span {
+  display: block;
+  text-align: center;
+}
+div.blackwhitelist.anidb, div.blackwhitelist.manual {
+  margin: 7px 0px;
+}
+
 /* for manage_massEdit */
 .optionWrapper {
   width: 450px;

--- a/gui/slick/interfaces/default/editShow.tmpl
+++ b/gui/slick/interfaces/default/editShow.tmpl
@@ -146,49 +146,7 @@ Separate words with a comma, e.g. "word1,word2,word3"
 <br /><br />
 
 #if $show.is_anime
-<p>
-Release Groups:
-</p>
-<input type="text" id="addToPoolText"/>
-<input type="button" value="Add to White" id="addToWhite">
-<input type="button" value="Add to Black" id="addToBlack"><br/>
-<div class="blackwhiteliste white">
-	<span>White:</span>
-	<select multiple id="white">
-			#for $keyword in $whitelist:
-				<option value="$keyword">$keyword</option>
-			#end for
-	</select>
-	<br/>
-	<input id="removeW" value="Remove &gt;&gt;" type="button"/>
-</div>
-
-<div class="blackwhiteliste pool">
-	<span>Pool (Name|Rating|Subed Ep):</span>
-	<select multiple id="pool">
-	#for $group in $groups
-		#if $group not in $whitelist and $group['name'] not in $blacklist:
-			<option value="$group['name']">$group['name'] | $group['rating'] | $group['range']</option>
-		#end if
-	#end for
-	</select>
-	<br/>
-	<input id="addW" value="&lt;&lt; Add" type="button"/>
-	<input id="addB" value="Add &gt;&gt;" type="button"/>
-	<input id="removeP" value="Remove" type="button"/>
-</div>
-
-<div class="blackwhiteliste black">
-	<span>Black:</span>
-	<select multiple id="black">
-		#for $keyword in $blacklist:
-			<option value="$keyword">$keyword</option>
-		#end for
-	</select>
-	<br/>
-	<input id="removeB" value="&lt;&lt; Remove" type="button"/>
-</div>
-<br style="clear:both;"/>
+#include $os.path.join($sickbeard.PROG_DIR, "gui/slick/interfaces/default/inc_blackwhitelist.tmpl")
 #end if
 <input type="hidden" name="whitelist" id="whitelist"/>
 <input type="hidden" name="blacklist" id="blacklist"/>

--- a/gui/slick/interfaces/default/inc_blackwhitelist.tmpl
+++ b/gui/slick/interfaces/default/inc_blackwhitelist.tmpl
@@ -1,0 +1,53 @@
+<b>Fansub Groups:</b>
+<div class="bwlWrapper" id="Anime">
+	<div class="component-group-desc">
+		<p>Select your preferred fansub groups from the <b>Available Groups</b> and add them to the <b>Whitelist</b>. Add groups to the <b>Blacklist</b> to ignore them.</p>
+		<p>The <b>Whitelist</b> is checked <i>before</i> the <b>Blacklist</b>.</p>
+		<p>Groups are shown as <b>Name</b> | <b>Rating</b> | <b>Number of subbed episodes</b>.</p>
+		<p>You may also add any fansub group not listed to either list manually.</p>
+	</div>
+	<div class="blackwhitelist all">
+		<div class="blackwhitelist anidb">
+			<div class="blackwhitelist white">
+				<span><h4>Whitelist</h4></span>
+				<select id="white" multiple="multiple" size="12">
+					#for $keyword in $whitelist:
+						<option value="$keyword">$keyword</option>
+					#end for
+				</select>
+				<br/>
+				<input class="btn" style="float: left;" id="removeW" value="Remove" type="button"/>
+			</div>
+			<div class="blackwhitelist pool">
+				<span><h4>Available Groups</h4></span>
+				<select id="pool" multiple="multiple" size="12">
+				#for $group in $groups
+					#if $group not in $whitelist and $group['name'] not in $blacklist:
+						<option value="$group['name']">$group['name'] | $group['rating'] | $group['range']</option>
+					#end if
+				#end for
+				</select>
+				<br/>
+				<input class="btn" style="float: left;" id="addW" value="Add to Whitelist" type="button"/>
+				<input class="btn" style="float: right;" id="addB" value="Add to Blacklist" type="button"/>
+			</div>
+			<div class="blackwhitelist black">
+				<span><h4>Blacklist</h4></span>
+				<select id="black" multiple="multiple" size="12">
+					#for $keyword in $blacklist:
+						<option value="$keyword">$keyword</option>
+					#end for
+				</select>
+				<br/>
+				<input class="btn" style="float: right;" id="removeB" value="Remove" type="button"/>
+			</div>
+		</div>
+		<br style="clear:both" />
+		<div class="blackwhitelist manual">
+			<input type="text" id="addToPoolText" size="30" />
+			<input class="btn" type="button" value="Add to Whitelist" id="addToWhite">
+			<input class="btn" type="button" value="Add to Blacklist" id="addToBlack">
+		</div>
+	</div>
+	<br style="clear:both" />
+</div>


### PR DESCRIPTION
Hi,

I noticed you have added the anime support of [lad1337's Sick Beard anime fork](https://github.com/lad1337/Sick-Beard) into SickRage. The black and whitelist management has a broken layout however. In the past I have submitted a [pull request](https://github.com/lad1337/Sick-Beard/commit/61318ab552125bac3e827a8003816dc61d3b1ff6) to his fork that fixed the issue and added several small improvements. Since these fixes did not make it into Sick Rage yet, I have created this pull request. It only needed a tiny bit of adjustment, one of which is that the black and whitelist is now an include that is only loaded if the show is marked as anime.

Kind regards,
Anthirian
