### PR TITLE
Fix next backlog date

### DIFF
--- a/gui/slick/interfaces/default/inc_bottom.tmpl
+++ b/gui/slick/interfaces/default/inc_bottom.tmpl
@@ -15,7 +15,7 @@
 #set $numEpisodes = $myDB.select("SELECT COUNT(*) FROM tv_episodes WHERE season != 0 and episode != 0 AND (airdate != 1 OR status IN ("+",".join([str(x) for x in ($Quality.DOWNLOADED + $Quality.SNATCHED + $Quality.SNATCHED_PROPER) + [$ARCHIVED]])+")) AND airdate <= "+$today+" AND status != "+str($IGNORED)+"")[0][0]
 <b>$numShows shows</b> ($numGoodShows active) | <b>$numDLEpisodes/$numEpisodes</b> episodes downloaded |
 <b>Search</b>: <%=str(sickbeard.dailySearchScheduler.timeLeft()).split('.')[0]%> |
-<b>Backlog</b>: $sbdatetime.sbdatetime.sbfdate($sickbeard.backlogSearchScheduler.nextRun())
+<b>Backlog</b>: <%=str(sickbeard.backlogSearchScheduler.timeLeft()).split('.')[0]%>
 </div>
 <ul style="float:right;">
         <li><a href="$sbRoot/manage/manageSearches/forceVersionCheck"><img src="$sbRoot/images/menu/update16.png" alt="" width="16" height="16" />Force Version Check</a></li>

--- a/sickbeard/searchBacklog.py
+++ b/sickbeard/searchBacklog.py
@@ -45,7 +45,7 @@ class BacklogSearcher:
     def __init__(self):
 
         self._lastBacklog = self._get_lastBacklog()
-        self.cycleTime = 7
+        self.cycleTime = sickbeard.BACKLOG_FREQUENCY/60/24
         self.lock = threading.Lock()
         self.amActive = False
         self.amPaused = False


### PR DESCRIPTION
Fixes next backlog date in API which currently uses 7 day cycle time regardless of config, Also changes display on UI which also used the 7 day cycle time as below:
Before:
![before](https://cloud.githubusercontent.com/assets/3397069/3423709/5a1ed436-ffa6-11e3-9ac7-fe083fa5e225.PNG)

After:
![after](https://cloud.githubusercontent.com/assets/3397069/3423712/5eaec894-ffa6-11e3-985d-f3b4bbfe4ac4.PNG)

I haven't altered the API to include a time as I wanted to ensure it didn't want it to break the compatibility with apps using the API - if you feel there is a low enough risk of it breaking anything I'm happy to make this alteration.
