### PR TITLE
Fixes web-dl quality detection for some episode naming patterns

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -222,13 +222,9 @@ class Quality:
             return Quality.RAWHDTV
         elif checkName(["1080p", "hdtv", "x264"], all):
             return Quality.FULLHDTV
-        elif checkName(["720p", "web.dl", "h.?264"], all) or checkName(["720p", "itunes", "h.?264"], all):
+        elif checkName(["720p", "web.dl|webrip"], all) or checkName(["720p", "itunes", "h.?264"], all):
             return Quality.HDWEBDL
-        elif checkName(["1080p", "web.dl", "h.?264"], all) or checkName(["1080p", "itunes", "h.?264"], all):
-            return Quality.FULLHDWEBDL
-        elif checkName(["720p", "webrip", "x264"], all):
-            return Quality.HDWEBDL
-        elif checkName(["1080p", "webrip", "x264"], all):
+        elif checkName(["1080p", "web.dl|webrip"], all) or checkName(["1080p", "itunes", "h.?264"], all):
             return Quality.FULLHDWEBDL
         elif checkName(["720p", "bluray|hddvd|b[r|d]rip", "x264"], all):
             return Quality.HDBLURAY


### PR DESCRIPTION
Porting code from SB. Fix for https://sickrage.tv/forums/forum/help-support/bug-issue-reports/3114-quality-detection-is-broken
