### PR TITLE
Added missing / to proxy url.

### DIFF
--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -64,7 +64,7 @@ class KATProvider(generic.TorrentProvider):
 
         self.cache = KATCache(self)
 
-        self.urls = ['http://kickass.to/', 'http://katproxy.com']
+        self.urls = ['http://kickass.to/', 'http://katproxy.com/']
 
     def isEnabled(self):
         return self.enabled


### PR DESCRIPTION
Fixes Error loading KickAssTorrents URL: (,ConnectionError(MaxRetryError("HTTPConnectionPool(host='katproxy.comusearch', port=80)
