### PR TITLE
Change SQL in templates.

### DIFF
--- a/gui/slick/interfaces/default/home.tmpl
+++ b/gui/slick/interfaces/default/home.tmpl
@@ -14,9 +14,36 @@
 
 #set $myDB = $db.DBConnection()
 #set $today = str($datetime.date.today().toordinal())
-#set $downloadedEps = $myDB.select("SELECT showid, COUNT(*) FROM tv_episodes WHERE (status IN ("+",".join([str(x) for x in $Quality.DOWNLOADED + [$ARCHIVED]])+") OR (status IN ("+",".join([str(x) for x in $Quality.SNATCHED + $Quality.SNATCHED_PROPER])+") AND location != '')) AND season != 0 and episode != 0 AND airdate <= "+$today+" GROUP BY showid")
-#set $allEps = $myDB.select("SELECT showid, COUNT(*) FROM tv_episodes WHERE season != 0 and episode != 0 AND (airdate != 1 OR status IN ("+",".join([str(x) for x in ($Quality.DOWNLOADED + $Quality.SNATCHED + $Quality.SNATCHED_PROPER) + [$ARCHIVED]])+")) AND airdate <= "+$today+" AND status != "+str($IGNORED)+" GROUP BY showid")
 #set $layout = $sickbeard.HOME_LAYOUT
+
+#set status_quality = '(' + ','.join([str(x) for x in $Quality.SNATCHED + $Quality.SNATCHED_PROPER]) + ')'
+#set status_download = '(' + ','.join([str(x) for x in $Quality.DOWNLOADED + [$ARCHIVED]]) + ')'
+
+#set $sql_statement = 'SELECT showid, '
+
+#set $sql_statement += '(SELECT COUNT(*) FROM tv_episodes WHERE showid=tv_eps.showid AND season > 0 AND episode > 0 AND airdate > 1 AND status IN ' + $status_quality + ') AS ep_snatched, '
+#set $sql_statement += '(SELECT COUNT(*) FROM tv_episodes WHERE showid=tv_eps.showid AND season > 0 AND episode > 0 AND airdate > 1 AND status IN ' + $status_download + ') AS ep_downloaded, '
+
+#set $sql_statement += '(SELECT COUNT(*) FROM tv_episodes WHERE showid=tv_eps.showid AND season > 0 AND episode > 0 AND airdate > 1 '
+#set $sql_statement += ' AND ((airdate <= ' + $today + ' AND (status = ' + str($SKIPPED) + ' OR status = ' + str($WANTED) + ')) '
+#set $sql_statement += ' OR (status IN ' + status_quality + ') OR (status IN ' + status_download + '))) AS ep_total, '
+
+#set $sql_statement += ' (SELECT airdate FROM tv_episodes WHERE showid=tv_eps.showid AND airdate >= ' + $today + ' AND (status = ' + str($UNAIRED) + ' OR status = ' + str($WANTED) + ') ORDER BY airdate ASC LIMIT 1) AS ep_airs_next '
+#set $sql_statement += ' FROM tv_episodes tv_eps GROUP BY showid'
+
+#set $sql_result = $myDB.select($sql_statement)
+
+#set $show_stat = {}
+#set $max_download_count = 1000
+
+#for $cur_result in $sql_result:
+    #set $show_stat[$cur_result['showid']] = $cur_result
+    #if $cur_result['ep_total'] > $max_download_count:
+        #set $max_download_count = $cur_result['ep_total']
+    #end if
+#end for
+
+#set $max_download_count = $max_download_count * 100
 
 <style type="text/css">
 .sort_data {display:none}
@@ -75,16 +102,23 @@
         match = s.match(/^(.*)/);
 
         if (match == null || match[1] == "?")
-            return -10;
+          return -10;
 
         var nums = match[1].split(" / ");
+        if (nums[0].indexOf("+") != -1) {
+            var num_parts = nums[0].split("+");
+            nums[0] = num_parts[0];
+        }
 
-        if (parseInt(nums[0]) === 0)
-        	return parseInt(nums[1]);
+        nums[0] = parseInt(nums[0])
+        nums[1] = parseInt(nums[1])
 
-        var finalNum = parseInt((nums[0]/nums[1])*1000)*100;
+        if (nums[0] === 0)
+          return nums[1];
+
+        var finalNum = parseInt($max_download_count*nums[0]/nums[1]);
         if (finalNum > 0)
-            finalNum += parseInt(nums[0]);
+          finalNum += nums[0];
 
         return finalNum;
     },
@@ -215,29 +249,58 @@
 $myShowList.sort(lambda x, y: cmp(x.name, y.name))
 #for $curShow in $myShowList:
 
-#set $curShowDownloads = [x[1] for x in $downloadedEps if int(x[0]) == $curShow.indexerid]
-#set $curShowAll = [x[1] for x in $allEps if int(x[0]) == $curShow.indexerid]
-#if len($curShowAll) != 0:
-  #if len($curShowDownloads) != 0:
-    #set $dlStat = str($curShowDownloads[0])+" / "+str($curShowAll[0])
-    #set $nom = $curShowDownloads[0]
-    #set $den = $curShowAll[0]
-  #else
-    #set $dlStat = "0 / "+str($curShowAll[0])
-    #set $nom = 0
-    #set $den = $curShowAll[0]
-  #end if
-#else
-  #set $dlStat = "0 / 0"
-  #set $nom = 0
-  #set $den = 1
-#end if
+    #set $cur_airs_next = ''
+    #set $cur_snatched = 0
+    #set $cur_downloaded = 0
+    #set $cur_total = 0
+    #set $download_stat_tip = ''
+
+    #if $curShow.indexerid in $show_stat:
+        #set $cur_airs_next = $show_stat[$curShow.indexerid]['ep_airs_next']
+
+        #set $cur_snatched = $show_stat[$curShow.indexerid]['ep_snatched']
+        #if not $cur_snatched:
+            #set $cur_snatched = 0
+        #end if
+
+        #set $cur_downloaded = $show_stat[$curShow.indexerid]['ep_downloaded']
+        #if not $cur_downloaded:
+            #set $cur_downloaded = 0
+        #end if
+
+        #set $cur_total = $show_stat[$curShow.indexerid]['ep_total']
+        #if not $cur_total:
+            #set $cur_total = 0
+        #end if
+    #end if
+
+    #if $cur_total != 0:
+        #set $download_stat = str($cur_downloaded)
+        #set $download_stat_tip = "Downloaded: " + str($cur_downloaded)
+        #if $cur_snatched > 0:
+            #set $download_stat = download_stat + "+" + str($cur_snatched)
+            #set $download_stat_tip = download_stat_tip + "&#013;" + "Snatched: " + str($cur_snatched)
+        #end if
+        #set $download_stat = download_stat + " / " + str($cur_total)
+        #set $download_stat_tip = download_stat_tip + "&#013;" + "Total: " + str($cur_total)
+    #else
+        #set $download_stat = '?'
+        #set $download_stat_tip = "no data"
+    #end if
+
+    #set $nom = $cur_downloaded
+    #set $den = $cur_total
+    #if $den == 0:
+        #set $den = 1
+    #end if
+
+#set $progressbar_percent = $nom * 100 / $den
 
 #set $which_thumb = $layout+"_thumb"
 
   <tr>
-    #if $curShow.nextaired:
-    #set $ldatetime = $network_timezones.parse_date_time($curShow.nextaired,$curShow.airs,$curShow.network)
+    #if $cur_airs_next:
+	#set $ldatetime = $network_timezones.parse_date_time($cur_airs_next,$curShow.airs,$curShow.network)
     	<td align="center" class="nowrap" style="color: #555555;font-weight:bold;"><div class="${fuzzydate}">$sbdatetime.sbdatetime.sbfdate($ldatetime)</div><span class="sort_data">$time.mktime($ldatetime.timetuple())</span> </td>
     #else:
     	<td align="center" class="nowrap" style="color: #555555;font-weight:bold;"></td>
@@ -282,17 +345,16 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
 #else:
     <td align="center"><span class="quality Custom">Custom</span></td>
 #end if
-    <td align="center"><span style="display: none;">$dlStat</span><div id="progressbar$curShow.indexerid" style="position:relative;"></div>
+    <td align="center"><span style="display: none;">$download_stat</span><div id="progressbar$curShow.indexerid" style="position:relative;"></div>
         <script type="text/javascript">
-        <!--
-            \$(function() {
-               \$("\#progressbar$curShow.indexerid").progressbar({
-       			value: parseInt($nom) * 100 / parseInt($den) / 1000 });
-               \$("\#progressbar$curShow.indexerid").append( "<div class='progressbarText'>$dlStat</div>" )
-				var progressBarWidth = parseInt($nom) * 100 / parseInt($den) + "%"
-               \$("\#progressbar$curShow.indexerid > .ui-progressbar-value").animate({ width: progressBarWidth }, 1000);
-            });
-        //-->
+          <!--
+                \$(function() {
+                 \$("\#progressbar$curShow.indexerid").progressbar({
+                     value: $progressbar_percent
+                 });
+                 \$("\#progressbar$curShow.indexerid").append("<div class='progressbarText' title='$download_stat_tip'>$download_stat</div>")
+                });
+          //-->
         </script>
     </td>
     <td align="center"><img src="$sbRoot/images/#if int($curShow.paused) == 0 and $curShow.status != "Ended" then "yes16.png\" alt=\"Y\"" else "no16.png\" alt=\"N\""# width="16" height="16" /></td>

--- a/gui/slick/interfaces/default/inc_bottom.tmpl
+++ b/gui/slick/interfaces/default/inc_bottom.tmpl
@@ -2,33 +2,53 @@
 #import datetime
 #from sickbeard import db, sbdatetime
 #from sickbeard.common import *
+
     </div>
 </div>
+
 <div class="footer clearfix">
+	<div class="meta" style="float:left;font-size: 12px;">
+		#set $myDB = $db.DBConnection()
+		#set $today = str($datetime.date.today().toordinal())
+		#set status_quality = '(' + ','.join([str(quality) for quality in $Quality.SNATCHED + $Quality.SNATCHED_PROPER]) + ')'
+		#set status_download = '(' + ','.join([str(quality) for quality in $Quality.DOWNLOADED + [$ARCHIVED]]) + ')'
 
-<div class="meta" style="float:left;font-size: 12px;">
-#set $myDB = $db.DBConnection()
-#set $today = str($datetime.date.today().toordinal())
+		#set $sql_statement = 'SELECT '
 
-#if $sickbeard.showList:
-#set $numShows = len($sickbeard.showList)
-#set $numGoodShows = len([x for x in $sickbeard.showList if x.paused == 0 and x.status != "Ended"])
-#else
-#set $numShows = 0
-#set $numGoodShows = 0
-#end if
+		#set $sql_statement += '(SELECT COUNT(*) FROM tv_episodes WHERE season > 0 AND episode > 0 AND airdate > 1 AND status IN ' + $status_quality + ') AS ep_snatched, '
+		#set $sql_statement += '(SELECT COUNT(*) FROM tv_episodes WHERE season > 0 AND episode > 0 AND airdate > 1 AND status IN ' + $status_download + ') AS ep_downloaded, '
 
-#set $numDLEpisodes = $myDB.select("SELECT COUNT(*) FROM tv_episodes WHERE status IN ("+",".join([str(x) for x in $Quality.DOWNLOADED + [$ARCHIVED]])+") AND season != 0 and episode != 0 AND airdate <= "+$today+"")[0][0]
-#set $numEpisodes = $myDB.select("SELECT COUNT(*) FROM tv_episodes WHERE season != 0 and episode != 0 AND (airdate != 1 OR status IN ("+",".join([str(x) for x in ($Quality.DOWNLOADED + $Quality.SNATCHED + $Quality.SNATCHED_PROPER) + [$ARCHIVED]])+")) AND airdate <= "+$today+" AND status != "+str($IGNORED)+"")[0][0]
-<b>$numShows shows</b> ($numGoodShows active) | <b>$numDLEpisodes/$numEpisodes</b> episodes downloaded |
-<b>Search</b>: <%=str(sickbeard.dailySearchScheduler.timeLeft()).split('.')[0]%> |
-<b>Backlog</b>: <%=str(sickbeard.backlogSearchScheduler.timeLeft()).split('.')[0]%>
-</div>
-<ul style="float:right;">
+		#set $sql_statement += '(SELECT COUNT(*) FROM tv_episodes WHERE season > 0 AND episode > 0 AND airdate > 1 '
+		#set $sql_statement += ' AND ((airdate <= ' + $today + ' AND (status = ' + str($SKIPPED) + ' OR status = ' + str($WANTED) + ')) '
+		#set $sql_statement += ' OR (status IN ' + status_quality + ') OR (status IN ' + status_download + '))) AS ep_total '
+
+		#set $sql_statement += ' FROM tv_episodes tv_eps LIMIT 1'
+	
+		#set $sql_result = $myDB.select($sql_statement)
+
+		#set $shows_total = len($sickbeard.showList)
+		#set $shows_active = len([show for show in $sickbeard.showList if show.paused == 0 and show.status != "Ended"])
+
+		#if $sql_result:
+			#set $ep_snatched = $sql_result[0]['ep_snatched']
+			#set $ep_downloaded = $sql_result[0]['ep_downloaded']
+			#set $ep_total = $sql_result[0]['ep_total']
+		#else
+			#set $ep_snatched = 0
+			#set $ep_downloaded = 0
+			#set $ep_total = 0
+		#end if
+		
+		<b>$shows_total</b> Shows (<b>$shows_active</b> Active) <b>|</b> <b><%=ep_downloaded%>#if $ep_snatched > 0 then " (+" + str($ep_snatched) + " snatched)" else ""# / $ep_total</b> Episodes Downloaded <b>|</b> Daily Search: <b><%=str(sickbeard.dailySearchScheduler.timeLeft()).split('.')[0]%></b> <b>|</b> Backlog Search: <b>$sbdatetime.sbdatetime.sbfdate($sickbeard.backlogSearchScheduler.nextRun())</b>
+	
+	</div>
+
+	<ul style="float:right; font-size: 12px;">
         <li><a href="$sbRoot/manage/manageSearches/forceVersionCheck"><img src="$sbRoot/images/menu/update16.png" alt="" width="16" height="16" />Force Version Check</a></li>
         <li><a href="$sbRoot/home/restart/?pid=$sbPID" class="confirm"><img src="$sbRoot/images/menu/restart16.png" alt="" width="16" height="16" />Restart</a></li>
         <li><a href="$sbRoot/home/shutdown/?pid=$sbPID" class="confirm"><img src="$sbRoot/images/menu/shutdown16.png" alt="" width="16" height="16" />Shutdown</a></li>
-</ul>
+	</ul>
 </div>
+	
 </body>
 </html>


### PR DESCRIPTION
Split downloaded and snatched
Use > instead of != in sql statement (speed improvement)
Today's Next Episode removes correctly if today's date is snatched or downloaded (fix)
Progressbar percentage calculated in python (speed improvement)
Episode totals changed so they no longer count ignored
