### PR TITLE
Remove old Code that caused an exception in the iCal Feed

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -416,8 +416,6 @@ class MainHandler(RequestHandler):
 
         logger.log(u"Receiving iCal request from %s" % self.request.remote_ip)
 
-        time_re = re.compile('([0-9]{1,2})\:([0-9]{2})(\ |)([AM|am|PM|pm]{2})')
-
         # Create a iCal string
         ical = 'BEGIN:VCALENDAR\r\n'
         ical += 'VERSION:2.0\r\n'


### PR DESCRIPTION
Remove unneeded old Codeline that caused an exception.

https://sickrage.tv/forums/forum/help-support/bug-issue-reports/5417-subscribing-for-calendar-to-coming-episodes-uncaught-exception
