### PR TITLE
fix episode filtering

### DIFF
--- a/gui/slick/js/displayShow.js
+++ b/gui/slick/js/displayShow.js
@@ -117,10 +117,6 @@ $(document).ready(function () {
     $("#checkboxControls input").change(function (e) {
         var whichClass = $(this).attr('id');
         $(this).showHideRows(whichClass);
-
-        $('tr.' + whichClass).each(function (i) {
-            $(this).toggle();
-        });
     });
 
     // initially show/hide all the rows according to the checkboxes


### PR DESCRIPTION
Checking the filtering checkboxes on episode listings did nothing on the first checkbox change, then did the opposite of what it was supposed (i.e. checking the checkbox would hide the episodes and vice versa).

Commit 95d7d728e00e225dd67a6f0eede10b41e5571ba8 eliminated 'return' statement in this function in `gui/slick/js/displayShow.js` - instead of adding the 'return' statement back it's cleaner to remove the code that 'return' was skipping over anyway. This fixes the issue.
