### PR TITLE
Fixed: pushbullet notifications don't work

### DIFF
--- a/sickbeard/notifiers/pushbullet.py
+++ b/sickbeard/notifiers/pushbullet.py
@@ -67,7 +67,7 @@ class PushbulletNotifier:
             pushbullet_device = sickbeard.PUSHBULLET_DEVICE
 
         if method == 'POST':
-            uri = '/api/pushes'
+            uri = '/v2/pushes'
         else:
             uri = '/api/devices'
 


### PR DESCRIPTION
Apparently the pushpubllet api URL has changed. I suspect it will be the case, in the future, to update the devices url (and maybe code) as well.
