### PR TITLE
hdbits gives 301 redirect when not using https url for api calls

### DIFF
--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -51,8 +51,8 @@ class HDBitsProvider(generic.TorrentProvider):
         self.cache = HDBitsCache(self)
 
         self.url = 'http://hdbits.org'
-        self.search_url = 'http://hdbits.org/api/torrents'
-        self.rss_url = 'http://hdbits.org/api/torrents'
+        self.search_url = 'https://hdbits.org/api/torrents'
+        self.rss_url = 'https://hdbits.org/api/torrents'
         self.download_url = 'http://hdbits.org/download.php?'
 
     def isEnabled(self):


### PR DESCRIPTION
Not sure if this happens to everyone or just me, but when not using https urls for api calls I get http 301 redirect return codes and SickRage subsequently fails
