### PR TITLE
Small Fix for HDbits JSON parsing error 

### DIFF
--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -50,10 +50,10 @@ class HDBitsProvider(generic.TorrentProvider):
 
         self.cache = HDBitsCache(self)
 
-        self.url = 'http://hdbits.org'
-        self.search_url = 'http://hdbits.org/api/torrents'
-        self.rss_url = 'http://hdbits.org/api/torrents'
-        self.download_url = 'http://hdbits.org/download.php?'
+        self.url = 'https://hdbits.org'
+        self.search_url = 'https://hdbits.org/api/torrents'
+        self.rss_url = 'https://hdbits.org/api/torrents'
+        self.download_url = 'https://hdbits.org/download.php?'
 
     def isEnabled(self):
         return self.enabled


### PR DESCRIPTION
Embalmed's Nonetype error still exists, JSON parsing is fixed over https though.
