### PR TITLE
Changes "no_season" regex to support XofX naming

### DIFF
--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -166,12 +166,13 @@ normal_regexes = [
      # 01 - Ep Name
      # 01 - Ep Name
      '''
-     ^((?P<series_name>.+?)(?:[. _-]{2,}|[. _]))?             # Show_Name and separator
-     (?P<ep_num>\d{1,2})                           # 02
-     (?:-(?P<extra_ep_num>\d{1,2}))*               # 02
-     [. _-]+((?P<extra_info>.+?)                 # Source_Quality_Etc-
-     ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
-     -(?P<release_group>[^- ]+([. _-]\[.*\])?))?)?$              # Group
+     ^((?P<series_name>.+?)(?:[. _-]{2,}|[. _]))?    # Show_Name and separator
+     (?P<ep_num>\d{1,3})                             # 02
+     (?:-(?P<extra_ep_num>\d{1,3}))*                 # -03-04-05 etc
+     \s?of?\s?\d{1,3}?                               # of joiner (with or without spaces) and series total ep
+     [. _-]+((?P<extra_info>.+?)                     # Source_Quality_Etc-
+     ((?<![. _-])(?<!WEB)                            # Make sure this is really the release group
+     -(?P<release_group>[^- ]+([. _-]\[.*\])?))?)?$  # Group
      '''
     ),
 


### PR DESCRIPTION
Previous version would allow for:

Britannia The Great Elizabethan Journey - 1 of 3 (19th May 2012) [HDTV 720p (x264)]

But disallow (because of no spaces around "of"):

Britannia The Great Elizabethan Journey - 1of3 (19th May 2012) [HDTV 720p (x264)]

Also previous extra_info changes from:
of 3 (19th May 2012) [HDTV 720p (x264)]

To:
(19th May 2012) [HDTV 720p (x264)]
