### PR TITLE
Update tvrage_api.py

### DIFF
--- a/lib/tvrage_api/tvrage_api.py
+++ b/lib/tvrage_api/tvrage_api.py
@@ -454,8 +454,11 @@ class TVRage:
                         value = value['#text']
                     if key == 'genre':
                         value = value['genre']
+                        if not value:
+                            value=[]
                         if not isinstance(value, list):
                             value = [value]
+                        value = filter(None, value)
                         value = '|' + '|'.join(value) + '|'
                 try:
                     if key == 'firstaired' and value in "0000-00-00":


### PR DESCRIPTION
Bugfix by viperidae
## Reference:

Reference: https://sickrage.tv/forums/forum/help-support/bug-issue-reports/6224-there-was-an-error-with-the-xml-retrieved-from-tvrage-com
## Quote:

Had a look at the code and the xml documents...

It looks like the problem is caused by an empty <genre /> element in Results/shows/show/genres/
Line 459 of tvrage_api.py (it's 460 in my track in the previous post because of the debug statements I put in)

I assume it's because value is NoneType, gets replaced by a [NoneType] list and then tries to call '|'.join([NoneType]) when it was expecting a list of strings.

I changed this to the following and the problem appears to be resolved
## Syslog extract:

tvrage_error: There was an error with the XML retrieved from tvrage.com
First try emptying the cache folder at..
C:\Users\User\Documents\Programs\SickRage\cache\indexers\TVRage
If this does not resolve the issue, please try again later. If the error persists, report a bug on

2014-08-09 00:43:25 INFO     SEARCHQUEUE-BACKLOG-74608 :: [NMatrix] :: Searching for episodes we need from Top Gear Season 21
2014-08-09 00:43:25 DB       SEARCHQUEUE-BACKLOG-74608 :: [NMatrix] :: cache.db: SELECT \* FROM [nmatrix] WHERE indexerid = ? AND season = ? AND episodes LIKE ? with args [74608, 21, '%|2|%']
2014-08-09 00:43:25 DB       SEARCHQUEUE-BACKLOG-74608 :: [NMatrix] :: cache.db: UPDATE lastSearch SET time = ? WHERE provider = ? with args [1407559405, 'nmatrix']
2014-08-09 00:43:25 DB       SEARCHQUEUE-BACKLOG-74608 :: [NMatrix] :: cache.db: INSERT INTO lastSearch (time, provider) VALUES (?, ?) with args [1407559405, 'nmatrix']
2014-08-09 00:43:25 DB       SEARCHQUEUE-BACKLOG-74608 :: [NMatrix] :: sickbeard.db: SELECT \* FROM indexer_mapping WHERE indexer_id = ? AND indexer = ? with args [74608, 1]
2014-08-09 00:43:25 ERROR    SEARCHQUEUE-BACKLOG-74608 :: [NMatrix] :: Error while searching NMatrix, skipping: There was an error with the XML retrieved from tvrage.com
First try emptying the cache folder at..
C:\Users\User\Documents\Programs\SickRage\cache\indexers\TVRage
If this does not resolve the issue, please try again later. If the error persists, report a bug on

2014-08-09 00:43:25 DEBUG    SEARCHQUEUE-BACKLOG-74608 :: [NMatrix] :: Traceback (most recent call last):
  File "C:\Users\User\Documents\Programs\SickRage\sickbeard\search.py", line 428, in searchProviders
    searchResults = curProvider.findSearchResults(show, season, episodes, search_mode, manualSearch)
  File "C:\Users\User\Documents\Programs\SickRage\sickbeard\providers\generic.py", line 264, in findSearchResults
    for curString in self._get_episode_search_strings(epObj):
  File "C:\Users\User\Documents\Programs\SickRage\sickbeard\providers\newznab.py", line 133, in _get_episode_search_strings
    rid = helpers.mapIndexersToShow(ep_obj.show)[2]
  File "C:\Users\User\Documents\Programs\SickRage\sickbeard\helpers.py", line 1178, in mapIndexersToShow
    mapped_show = t[showObj.name]
  File "C:\Users\User\Documents\Programs\SickRage\lib\tvrage_api\tvrage_api.py", line 675, in __getitem__
    selected_series = self._getSeries(key)
  File "C:\Users\User\Documents\Programs\SickRage\lib\tvrage_api\tvrage_api.py", line 566, in _getSeries
    allSeries = self.search(series)
  File "C:\Users\User\Documents\Programs\SickRage\lib\tvrage_api\tvrage_api.py", line 557, in search
    seriesEt = self._getetsrc(self.config['url_getSeries'], self.config['params_getSeries'])
  File "C:\Users\User\Documents\Programs\SickRage\lib\tvrage_api\tvrage_api.py", line 500, in _getetsrc
    raise tvrage_error(errormsg)
