### PR TITLE
Add priority option for daily snatches (inc force)

### DIFF
--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -313,6 +313,76 @@
                                     <span class="component-desc">Category for downloads to go into (eg. TV)</span>
                                 </label>
                             </div>
+
+                            <%
+                                    if config['nzbget_priority'] == -100:
+                                        prio_verylow = 'selected="selected"'
+                                        prio_low = ''
+                                        prio_normal = ''
+                                        prio_high = ''
+                                        prio_veryhigh = ''
+                                        prio_force = ''
+                                    elif config['nzbget_priority'] == -50:
+                                        prio_verylow = ''
+                                        prio_low = 'selected="selected"'
+                                        prio_normal = ''
+                                        prio_high = ''
+                                        prio_veryhigh = ''
+                                        prio_force = ''
+                                    elif config['nzbget_priority'] == 0:
+                                        prio_verylow = ''
+                                        prio_low = ''
+                                        prio_normal = 'selected="selected"'
+                                        prio_high = ''
+                                        prio_veryhigh = ''
+                                        prio_force = ''
+                                    elif config['nzbget_priority'] == 50:
+                                        prio_verylow = ''
+                                        prio_low = ''
+                                        prio_normal = ''
+                                        prio_high = 'selected="selected"'
+                                        prio_veryhigh = ''
+                                        prio_force = ''
+                                    elif config['nzbget_priority'] == 100:
+                                        prio_verylow = ''
+                                        prio_low = ''
+                                        prio_normal = ''
+                                        prio_high = ''
+                                        prio_veryhigh = 'selected="selected"'
+                                        prio_force = ''
+                                    elif config['nzbget_priority'] == 900:
+                                        prio_verylow = ''
+                                        prio_low = ''
+                                        prio_normal = ''
+                                        prio_high = ''
+                                        prio_veryhigh = ''
+                                        prio_force = 'selected="selected"'
+                                    else:
+                                        prio_verylow = ''
+                                        prio_low = ''
+                                        prio_normal = 'selected="selected"'
+                                        prio_high = ''
+                                        prio_veryhigh = ''
+                                        prio_force = ''
+                                %>
+
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">NZBget Priority</span>
+                                    <select name="nzbget_priority" id="nzbget_priority">
+                                        <option value="-100" ${prio_verylow}>Very Low</option>
+                                        <option value="-50" ${prio_low}>Low</option>
+                                        <option value="0" ${prio_normal}>Normal</option>
+                                        <option value="50" ${prio_high}>High</option>
+                                        <option value="100" ${prio_veryhigh}>Very High</option>
+                                        <option value="900" ${prio_force}>Force</option>
+                                    </select>
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Priority for daily snatches (no backlog)</span>
+                                </label>
+                            </div>
                         </div>
                         
                         <div class="clearfix"></div>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -240,6 +240,7 @@ NZBGET_PASSWORD = None
 NZBGET_CATEGORY = None
 NZBGET_HOST = None
 NZBGET_USE_HTTPS = False
+NZBGET_PRIORITY = 100
 
 TORRENT_USERNAME = None
 TORRENT_PASSWORD = None
@@ -446,7 +447,7 @@ def initialize(consoleLogging=True):
         global BRANCH, ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, ENCRYPTION_VERSION, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
             HANDLE_REVERSE_PROXY, USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, CHECK_PROPERS_INTERVAL, ALLOW_HIGH_PRIORITY, TORRENT_METHOD, \
             SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
-            NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, NZBGET_USE_HTTPS, backlogSearchScheduler, \
+            NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_PRIORITY, NZBGET_HOST, NZBGET_USE_HTTPS, backlogSearchScheduler, \
             TORRENT_USERNAME, TORRENT_PASSWORD, TORRENT_HOST, TORRENT_PATH, TORRENT_SEED_TIME, TORRENT_PAUSED, TORRENT_HIGH_BANDWIDTH, TORRENT_LABEL, TORRENT_VERIFY_CERT, \
             USE_XBMC, XBMC_ALWAYS_ON, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_NOTIFY_ONSUBTITLEDOWNLOAD, XBMC_UPDATE_FULL, XBMC_UPDATE_ONLYFIRST, \
             XBMC_UPDATE_LIBRARY, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, BACKLOG_FREQUENCY, \
@@ -691,6 +692,7 @@ def initialize(consoleLogging=True):
         NZBGET_CATEGORY = check_setting_str(CFG, 'NZBget', 'nzbget_category', 'tv')
         NZBGET_HOST = check_setting_str(CFG, 'NZBget', 'nzbget_host', '')
         NZBGET_USE_HTTPS = bool(check_setting_int(CFG, 'NZBget', 'nzbget_use_https', 0))
+        NZBGET_PRIORITY = check_setting_int(CFG, 'NZBget', 'nzbget_priority', 100)
 
         TORRENT_USERNAME = check_setting_str(CFG, 'TORRENT', 'torrent_username', '')
         TORRENT_PASSWORD = check_setting_str(CFG, 'TORRENT', 'torrent_password', '')
@@ -1498,6 +1500,7 @@ def save_config():
     new_config['NZBget']['nzbget_category'] = NZBGET_CATEGORY
     new_config['NZBget']['nzbget_host'] = NZBGET_HOST
     new_config['NZBget']['nzbget_use_https'] = int(NZBGET_USE_HTTPS)
+    new_config['NZBget']['nzbget_priority'] = NZBGET_PRIORITY
 
     new_config['TORRENT'] = {}
     new_config['TORRENT']['torrent_username'] = TORRENT_USERNAME

--- a/sickbeard/nzbget.py
+++ b/sickbeard/nzbget.py
@@ -82,7 +82,7 @@ def sendNZB(nzb, proper=False):
         dupekey += "-" + str(curEp.season) + "." + str(curEp.episode)
         if datetime.date.today() - curEp.airdate <= datetime.timedelta(days=7):
             addToTop = True
-            nzbgetprio = 100
+            nzbgetprio = sickbeard.NZBGET_PRIORITY
 
     if nzb.quality != Quality.UNKNOWN:
         dupescore = nzb.quality * 100

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1601,7 +1601,7 @@ class ConfigSearch(MainHandler):
 
     def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, sab_username=None, sab_password=None,
                    sab_apikey=None, sab_category=None, sab_host=None, nzbget_username=None, nzbget_password=None,
-                   nzbget_category=None, nzbget_host=None, nzbget_use_https=None, dailysearch_frequency=None,
+                   nzbget_category=None, nzbget_priority=100, nzbget_host=None, nzbget_use_https=None, dailysearch_frequency=None,
                    nzb_method=None, torrent_method=None, usenet_retention=None, backlog_frequency=None,
                    download_propers=None, check_propers_interval=None, allow_high_priority=None,
                    backlog_startup=None, dailysearch_startup=None,
@@ -1648,6 +1648,7 @@ class ConfigSearch(MainHandler):
         sickbeard.NZBGET_CATEGORY = nzbget_category
         sickbeard.NZBGET_HOST = config.clean_host(nzbget_host)
         sickbeard.NZBGET_USE_HTTPS = config.checkbox_to_value(nzbget_use_https)
+        sickbeard.NZBGET_PRIORITY = int(nzbget_priority)
 
         sickbeard.TORRENT_USERNAME = torrent_username
         sickbeard.TORRENT_PASSWORD = torrent_password


### PR DESCRIPTION
This adds a priority option that allows the user to specify the
priority to be used for daily/recent snatches instead of the default
high value ‘100’.

This also includes the use of priority ‘force’ which will let nzbget
download the task even if the queue is paused.
