### PR TITLE
Scene exception list not updated, Double show names in scene excep list after manual scan

### DIFF
--- a/sickbeard/scene_exceptions.py
+++ b/sickbeard/scene_exceptions.py
@@ -256,11 +256,17 @@ def update_scene_exceptions(indexer_id, scene_exceptions, season=-1):
     """
     Given a indexer_id, and a list of all show scene exceptions, update the db.
     """
-
+    global exceptionsCache
     myDB = db.DBConnection('cache.db')
     myDB.action('DELETE FROM scene_exceptions WHERE indexer_id=?', [indexer_id])
 
     logger.log(u"Updating scene exceptions", logger.MESSAGE)
+    
+    # A change has been made to the scene exception list. Let's clear the cache, to make this visible
+    if indexer_id in exceptionsCache:
+        exceptionsCache[indexer_id] = {}
+        exceptionsCache[indexer_id][season] = scene_exceptions
+
     for cur_exception in scene_exceptions:
 
         if not isinstance(cur_exception, unicode):
@@ -316,7 +322,7 @@ def _xem_exceptions_fetcher():
 
 
 def getSceneSeasons(indexer_id):
-    """get a list of season numbers that have scene excpetions
+    """get a list of season numbers that have scene exceptions
     """
     myDB = db.DBConnection('cache.db')
     seasons = myDB.select("SELECT DISTINCT season FROM scene_exceptions WHERE indexer_id = ?", [indexer_id])

--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -259,10 +259,10 @@ def allPossibleShowNames(show, season=-1):
     Returns: a list of all the possible show names
     """
 
-    showNames = get_scene_exceptions(show.indexerid, season=season)
+    showNames = get_scene_exceptions(show.indexerid, season=season)[:]
     if not showNames:  # if we dont have any season specific exceptions fallback to generic exceptions
         season = -1
-        showNames = get_scene_exceptions(show.indexerid, season=season)
+        showNames = get_scene_exceptions(show.indexerid, season=season)[:]
 
     if season in [-1, 1]:
         showNames.append(show.name)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -556,7 +556,7 @@ def _getEpisode(show, season=None, episode=None, absolute=None):
         return "Invalid show paramaters"
 
     if absolute:
-        epObj = showObj.getEpisode(absolute=int(absolute))
+        epObj = showObj.getEpisode(absolute_number=int(absolute))
     elif season and episode:
         epObj = showObj.getEpisode(int(season), int(episode))
     else:


### PR DESCRIPTION
webserve.py: small typo that prevented the absolute "scene absolute" numbering to update in the displayShow page.

scene_exceptions.py: scene exceptions were not saved. the exceptionCache variable used to cache the scene exceptions. The list with exceptions is updated in db, but when reopening your series edit page, the scene exception list is retrieved from the cache instead the db. I've created a small patch that updates the cache after updating the scene exceptions in db.

show_name_helpers.py: After each manual search the showName was added to the scene exceptions list. This was only added to the cache, but was anoying because up until a restart the list with scene exception names kept growing. Fixed this by refering to the function by value instead of by reference.
