### PR TITLE
Should fix some utorrent, rtorrent and deluge

### DIFF
--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -143,14 +143,15 @@ class GenericClient(object):
     def _get_torrent_hash(self, result):
 
         if result.url.startswith('magnet'):
-            torrent_hash = re.findall('urn:btih:([\w]{32,40})', result.url)[0]
-            if len(torrent_hash) == 32:
-                torrent_hash = b16encode(b32decode(torrent_hash)).lower()
+            result.hash = re.findall('urn:btih:([\w]{32,40})', result.url)[0]
+            if len(result.hash) == 32:
+                result.hash = b16encode(b32decode(torrent_hash)).lower()
         else:
+            result.content = result.provider.getURL(result.url)
             info = bdecode(result.content)["info"]
-            torrent_hash = sha1(bencode(info)).hexdigest()
+            result.hash = sha1(bencode(info)).hexdigest()
 
-        return torrent_hash
+        return result
 
     def sendTORRENT(self, result):
 


### PR DESCRIPTION
 problems.
This commit essentially undoes https://github.com/echel0n/SickRage/commit/54afca04725be05a73b4ab009e60cb5b146768cb

The utorrent, rtorrent and deluge methods were still using result.hash to set label, seed ratio and priority etc (instead of torrent_hash which the commit referenced above changed it to).
I've changed it back to result.hash in this commit.

Reference problem posts:
https://sickrage.tv/forums/forum/help-support/bug-issue-reports/7493-utorrent-unable-to-send-torrent
https://sickrage.tv/forums/forum/help-support/bug-issue-reports/7533-sickrage-not-sending-tv-label-to-utorrent
https://sickrage.tv/forums/forum/help-support/bug-issue-reports/7541-bug-rtorrent-unable-to-send-torrent
... 
