### PR TITLE
notifiers/libnotify: fix syntax error from #624

### DIFF
--- a/sickbeard/notifiers/libnotify.py
+++ b/sickbeard/notifiers/libnotify.py
@@ -95,7 +95,8 @@ class LibnotifyNotifier:
             
     def notify_git_update(self, new_version = "??"):
         if sickbeard.USE_LIBNOTIFY:
-            update_text=common.notifyStrings[common.NOTIFY_GIT_UPDATE_TEXT], title=common.notifyStrings[common.NOTIFY_GIT_UPDATE]
+            update_text=common.notifyStrings[common.NOTIFY_GIT_UPDATE_TEXT]
+            title=common.notifyStrings[common.NOTIFY_GIT_UPDATE]
             self._notify(title, update_text + new_version)
 
     def test_notify(self):


### PR DESCRIPTION
Prior to this got error 'too many values to unpack' when updating and libnotify notifications were enabled.
