### PR TITLE
Fixed missing slash on Kat mirror URL

### DIFF
--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -61,7 +61,7 @@ class KATProvider(generic.TorrentProvider):
 
         self.cache = KATCache(self)
 
-        self.urls = ['http://kickass.to/', 'http://katproxy.com/', 'http://www.kickmirror.com']
+        self.urls = ['http://kickass.to/', 'http://katproxy.com/', 'http://www.kickmirror.com/']
         self.url = None
 
     def isEnabled(self):


### PR DESCRIPTION
The new Kat mirror http://www.kickmirror.com was missing a slash at the end resulting in incorrect search urls: SEARCHQUEUE-MANUAL-279827 :: [KickAssTorrents] :: Connection error HTTPConnectionPool(host='www.kickmirror.comusearch', port=80): Max retries exceeded with url: /Series.Name/?field=seeders&sorder=desc (Caused by : [Errno -2] Name or service not known) while loading URL http://www.kickmirror.comusearch/Series.Name/?field=seeders&sorder=desc
