### PR TITLE
Fix for empty values in RSS Torrents

### DIFF
--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -53,9 +53,14 @@ class TorrentRssProvider(generic.TorrentProvider):
         self.cookies = cookies
 
     def configStr(self):
-        return self.name + '|' + self.url + '|' + self.cookies + '|' + str(
-            int(self.enabled)) + '|' + self.search_mode + '|' + str(int(self.search_fallback)) + '|' + str(
-            int(self.enable_daily)) + '|' + str(int(self.enable_backlog))
+        return "%s|%s|%s|%d|%s|%d|%d|%d" % (self.name or '',
+                                            self.url or '',
+                                            self.cookies or '',
+                                            self.enabled,
+                                            self.search_mode or '',
+                                            self.search_fallback,
+                                            self.enable_daily,
+                                            self.enable_backlog)
 
     def imageName(self):
         if ek.ek(os.path.isfile,


### PR DESCRIPTION
I had an custom RSS provider setup from before cookie support was introduced.   Because of this SickRage could not restart as it would get an error trying to write the configuration line for the provider:

```
sickbeard_stderr.log:Exception in thread EVENT-QUEUE:
sickbeard_stderr.log-Traceback (most recent call last):
sickbeard_stderr.log-  File "/usr/local/Cellar/python/2.7.8_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
sickbeard_stderr.log-    self.run()
sickbeard_stderr.log-  File "/opt/software/TPB/sickbeard/event_queue.py", line 31, in run
sickbeard_stderr.log-    self.callback(type)
sickbeard_stderr.log-  File "/opt/software/TPB/Sickbeard.py", line 482, in shutdown
sickbeard_stderr.log-    sickbeard.saveAll()
sickbeard_stderr.log-  File "/opt/software/TPB/sickbeard/__init__.py", line 1312, in saveAll
sickbeard_stderr.log-    save_config()
sickbeard_stderr.log-  File "/opt/software/TPB/sickbeard/__init__.py", line 1712, in save_config
sickbeard_stderr.log-    new_config['TorrentRss']['torrentrss_data'] = '!!!'.join([x.configStr() for x in torrentRssProviderList])
sickbeard_stderr.log-  File "/opt/software/TPB/sickbeard/providers/rsstorrent.py", line 66, in configStr
sickbeard_stderr.log-    int(self.enable_daily)) + '|' + str(int(self.enable_backlog))
sickbeard_stderr.log-TypeError: cannot concatenate 'str' and 'NoneType' objects
sickbeard_stderr.log-
```

This pull request fixes that and makes formatting the string a little nicer to look at.
