### PR TITLE
add searchstrings for searching newznab providers excluding the ep= paramater.

### DIFF
--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -214,7 +214,7 @@ class NewznabProvider(generic.NZBProvider):
             params['q'] = helpers.sanitizeSceneName(cur_exception)
             paramsNoEp = params.copy()
             
-            paramsNoEp['q'] += paramsNoEp['q'] + " " + paramsNoEp['ep']
+            paramsNoEp['q'] += paramsNoEp['q'] + " " + str(paramsNoEp['ep'])
             if "ep" in paramsNoEp:
                 paramsNoEp.pop("ep")
             to_return.append(paramsNoEp)


### PR DESCRIPTION
Experimental!
Add searchstrings for searching newznab providers excluding the ep= paramater. I've added the episode to the q= param. querystring could look like: ?q=showname%2043.

This is usefull for newznab providers who are missing episode parsing for certain shows. For example, nzedb providers are missing show/ep/season parsing for Anime.
