### PR TITLE
Bug in master while doing daily search: https://sickrage.tv/forums/forum/help-support/bug-issue-reports/8358-unsupported-operand-type-s-for-dict-and-dict

### DIFF
--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -207,7 +207,7 @@ class GenericProvider:
         results = {}
 
         for ep in episode:
-            results.copy(self.cache.findNeededEpisodes(ep))
+            results.update(self.cache.findNeededEpisodes(ep))
 
         return results
 


### PR DESCRIPTION
Bug in master while doing daily search: https://sickrage.tv/forums/forum/help-support/bug-issue-reports/8358-unsupported-operand-type-s-for-dict-and-dict.
Tested, and this fixes the += dict issue. Don't know if daily search is working tough.
