### PR TITLE
Updates to Pushbullet functionality to address rejected keys / connections, provide "All Devices" functionality

### DIFF
--- a/gui/slick/js/configNotifications.js
+++ b/gui/slick/js/configNotifications.js
@@ -267,6 +267,7 @@ $(document).ready(function(){
             function (data) {
                 var devices = jQuery.parseJSON(data).devices;
                 $("#pushbullet_device_list").html('');
+                $("#pushbullet_device_list").append('<option value="" selected>-- All Devices --</option>')
                 for (var i = 0; i < devices.length; i++) {
                     if(devices[i].active == true) {
                         if(current_pushbullet_device == devices[i].iden) {

--- a/sickbeard/notifiers/pushbullet.py
+++ b/sickbeard/notifiers/pushbullet.py
@@ -79,13 +79,11 @@ class PushbulletNotifier:
 
         http_handler = HTTPSConnection("api.pushbullet.com")
 
-        authString = base64.encodestring('%s:' % (pushbullet_api)).replace('\n', '')
-
         if notificationType == None:
             testMessage = True
             try:
                 logger.log(u"Testing Pushbullet authentication and retrieving the device list.", logger.DEBUG)
-                http_handler.request(method, uri, None, headers={'Authorization': 'Basic %s:' % authString})
+                http_handler.request(method, uri, None, headers={'Authorization': 'Bearer %s' % pushbullet_api})
             except (SSLError, HTTPException, socket.error):
                 logger.log(u"Pushbullet notification failed.", logger.ERROR)
                 return False
@@ -99,7 +97,7 @@ class PushbulletNotifier:
                     'type': notificationType}
                 data = json.dumps(data)
                 http_handler.request(method, uri, body=data,
-                                     headers={'Content-Type': 'application/json', 'Authorization': 'Basic %s' % authString})
+                                     headers={'Content-Type': 'application/json', 'Authorization': 'Bearer %s' % pushbullet_api})
                 pass
             except (SSLError, HTTPException, socket.error):
                 return False


### PR DESCRIPTION
- Update Pushbullet notifier to no longer base64 encode the API key which was causing Pushbullet to reject the key and connections
- Update Pushbullet notifier's authorization header to reflect their API
- Update the JS that populates the Pushbullet device list to provide an "All Devices" option
