### PR TITLE
This is a check used in webserve.py getManualSearchStatus(), to get the ...

### DIFF
--- a/sickbeard/search_queue.py
+++ b/sickbeard/search_queue.py
@@ -84,9 +84,9 @@ class SearchQueue(generic_queue.GenericQueue):
         return self.min_priority >= generic_queue.QueuePriorities.NORMAL
 
     def is_manualsearch_in_progress(self):
-        for cur_item in self.queue + [self.currentItem]:
-            if isinstance(cur_item, (ManualSearchQueueItem, FailedQueueItem)):
-                return True
+        # Only referenced in webserve.py, only current running manualsearch or failedsearch is needed!!
+        if isinstance(self.currentItem, (ManualSearchQueueItem, FailedQueueItem)):
+            return True
         return False
     
     def is_backlog_in_progress(self):


### PR DESCRIPTION
...current running queuitem, if it is a manual or failed/retry search. If so, the frontend will report the matching episode as in status "searching".

The function is_manualsearch_in_progress() is introduced for this purpose and only reference in webserve.py.
Previously when a daily search is running, and a manual search is queued behind it, it will wrongly give back that the manual search is running, this could result in unexpected behavior.
