### PR TITLE
Catch airs/network set to None

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -468,7 +468,7 @@ class MainHandler(RequestHandler):
                     ical = ical + 'DESCRIPTION:' + show['airs'] + ' on ' + show['network'] + '\\n\\n' + \
                            episode['description'].splitlines()[0] + '\r\n'
                 else:
-                    ical = ical + 'DESCRIPTION:' + show['airs'] + ' on ' + show['network'] + '\r\n'
+                    ical = ical + 'DESCRIPTION:' + (show['airs'] or '(Unknown airs)') + ' on ' + (show['network'] or 'Unknown network') + '\r\n'
                 ical = ical + 'LOCATION:' + 'Episode ' + str(episode['episode']) + ' - Season ' + str(
                     episode['season']) + '\r\n'
                 ical = ical + 'END:VEVENT\r\n'


### PR DESCRIPTION
Some shows don't have a network set, which causes an exception when the value is coerced to Unicode.
