### PR TITLE
Fixes and additions to testRename.tmpl

### DIFF
--- a/gui/slick/interfaces/default/testRename.tmpl
+++ b/gui/slick/interfaces/default/testRename.tmpl
@@ -69,7 +69,7 @@
             #else
                 wanted
             #end if
-        ">
+        seasonstyle">
             <td width="1%" valign="top" align="center" class="tableleft">
 			#if $curLoc != $newLoc:
                 <input type="checkbox" class="epCheck" id="<%=str(cur_ep_obj.season) + 'x' + str(cur_ep_obj.episode)%>" name="<%=str(cur_ep_obj.season) + "x" + str(cur_ep_obj.episode) %>" />


### PR DESCRIPTION
Good named episodes show in green now and cannot be selected since it's
pointless.
Cancel Rename button added to return you to show page if you wish to
cancel.
