### PR TITLE
Fixes SR setting SeedIdleLimit no matter what

### DIFF
--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -558,7 +558,7 @@
                                 <label class="nocheck clearfix">
                                     <span class="component-title">&nbsp;</span>
                                     <span class="component-desc">Duration (in hours) to seed for<br>
-                                    (SickRage default '0' passes blank to downloader)</span>
+                                    (SickRage default '0' passes blank to downloader; '-1' does not set Seed Time)</span>
                                 </label>
                             </div>
 

--- a/sickbeard/clients/transmission.py
+++ b/sickbeard/clients/transmission.py
@@ -107,7 +107,7 @@ class TransmissionAPI(GenericClient):
 
     def _set_torrent_seed_time(self, result):
 
-        if sickbeard.TORRENT_SEED_TIME:
+        if sickbeard.TORRENT_SEED_TIME and sickbeard.TORRENT_SEED_TIME != -1:
             time = int(60 * float(sickbeard.TORRENT_SEED_TIME))
             arguments = {'ids': [result.hash],
                          'seedIdleLimit': time,


### PR DESCRIPTION
Any setting will set a SeedIdleLimit in Transmission even if your client default is to not have SeedIdleLimit enabled. This allows a setting of '-1' to bypass setting the SeedIdleLimit thereby not stopping torrent seeding based on this limit.
