### PR TITLE
Fixes calendar always being unprotected

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -95,8 +95,9 @@ def authenticated(handler_class):
             try:
                 if not (sickbeard.WEB_USERNAME and sickbeard.WEB_PASSWORD):
                     return True
-                elif handler.request.uri.startswith('/calendar') or (
-                            handler.request.uri.startswith('/api') and '/api/builder' not in handler.request.uri):
+                elif (handler.request.uri.startswith('/api') and '/api/builder' not in handler.request.uri):
+                    return True
+                elif (handler.request.uri.startswith('/calendar') and sickbeard.CALENDAR_UNPROTECTED):
                     return True
 
                 auth_hdr = handler.request.headers.get('Authorization')


### PR DESCRIPTION
SR will now make use of the "unprotected calendar" option in the advanced settings. Before this commit it was always possible to view calendar without any username and password.

While this fixes the option, it will also by default protect the calender (because CALENDAR_UNPROTECTED is FALSE by default). Therefore some people might 'suddenly' lose access to their calendar. To prevent complaints one might want to migrate the config to turn CALENDAR_UNPROTECTED to true, but I think this a bad choice because this will result in the calendar not being protected for everybody again...

This is my first pull request; let me know if I did something wrong. :)

[Issue report](https://sickrage.tv/forums/forum/help-support/bug-issue-reports/8904-calendar-always-unportected)
