### PR TITLE
Improve addShows trending page by using less memory and loading quicker.

### DIFF
--- a/gui/slick/interfaces/default/home_trendingShows.tmpl
+++ b/gui/slick/interfaces/default/home_trendingShows.tmpl
@@ -23,14 +23,15 @@
 
 <table id="trakt" width="100%" cellspacing="1" border="0" cellpadding="0">
 #for $i, $cur_show in $enumerate($trending_shows):
-#if not $i%6
+#set $image = re.sub(r"(.*)(\..*?)$", r"\1-300\2", $cur_show["images"]["poster"], 0, re.IGNORECASE | re.MULTILINE)
+#if not $i%5
 <tr>
 #end if
 
 <td class="trakt_show">
 	<div class="traktContainer">
 	<div class="trakt-image">
-    <a href="${cur_show["url"]}" target="_blank"><img alt="" class="trakt-image" src="${cur_show["images"]["poster"]}" /></a>
+    <a href="${cur_show["url"]}" target="_blank"><img alt="" class="trakt-image" src="${image}" /></a>
 		<div class="trakt-image-slide">
 			<p>$cur_show["title"]</p>
 		</div>


### PR DESCRIPTION
The trending page shows approx. 500 images and typically, the size of fetched images were 1000 x 1500 pixels. The browser was relied on to reduce the images while rendering to 186 x 273 pixels. The result used a _lot_ of memory, bandwidth, time, render processing, and server resources to populate the page so those issues have been eased by fetching smaller 300 x 450 pixel images instead.

Reduced the number of cards on a line by one to accommodate smaller page width.
