### PR TITLE
Fix IMDB watch list import, setting invalid status, so changed to user default

### DIFF
--- a/sickbeard/automations/imdbChecker.py
+++ b/sickbeard/automations/imdbChecker.py
@@ -187,7 +187,8 @@ class IMDB(ImdbBase):
                 else:
                     helpers.chmodAsParent(showPath)
 
-                sickbeard.showQueueScheduler.action.addShow(int(indexer), int(indexer_id), showPath, status,
+                sickbeard.showQueueScheduler.action.addShow(int(indexer), int(indexer_id), showPath,
+                                                            int(sickbeard.STATUS_DEFAULT),
                                                             int(sickbeard.QUALITY_DEFAULT),
                                                             int(sickbeard.FLATTEN_FOLDERS_DEFAULT),
                                                             paused=False, anime = False)


### PR DESCRIPTION
Fix IMDB status, currently when importing shows from IMDB it would give episodes an invalid status
