### PR TITLE
Fix the BeautifySoup find for class torrents for iptorrents

### DIFF
--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -183,7 +183,7 @@ class IPTorrentsProvider(generic.TorrentProvider):
                             logger.log(u"No results found for: " + search_string + " (" + searchURL + ")", logger.DEBUG)
                             continue
 
-                        torrent_table = html.find('table', attrs={'class': 'torrents'})
+                        torrent_table = html.find('table', class_="torrents")
                         torrents = torrent_table.find_all('tr') if torrent_table else []
 
                         #Continue only if one Release is found


### PR DESCRIPTION
Finding the torrent table for iptorrents kept seeing the error log "The Data returned from IPTorrents do not contains any torrent", however the table class was not found.
