### PR TITLE
Fix quick adding of existing shows (mostly)

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2847,18 +2847,19 @@ class NewHomeAddShows(MainHandler):
 
                 indexer_id = show_name = indexer = None
                 for cur_provider in sickbeard.metadata_provider_dict.values():
-                    (indexer_id, show_name, indexer) = cur_provider.retrieveShowMetadata(cur_path)
+                    if not (indexer_id and show_name and indexer):
+                        (indexer_id, show_name, indexer) = cur_provider.retrieveShowMetadata(cur_path)
 
-                    # default to TVDB if indexer was not detected
-                    if show_name and not (indexer or indexer_id):
-                        (sn, idx, id) = helpers.searchIndexerForShowID(show_name, indexer, indexer_id)
+                        # default to TVDB if indexer was not detected
+                        if show_name and not (indexer or indexer_id):
+                            (sn, idx, id) = helpers.searchIndexerForShowID(show_name, indexer, indexer_id)
 
-                        # set indexer and indexer_id from found info
-                        if not indexer and idx:
-                            indexer = idx
+                            # set indexer and indexer_id from found info
+                            if not indexer and idx:
+                                indexer = idx
 
-                        if not indexer_id and id:
-                            indexer_id = id
+                            if not indexer_id and id:
+                                indexer_id = id
 
                 cur_dir['existing_info'] = (indexer_id, show_name, indexer)
 


### PR DESCRIPTION
Strips the year from the show name when manually adding, so the search box populates correctly and finds the show without having to remove the year and search again.

Fix error where indexer, indexer_id, and show_name were never returned in massAddTable.
After the values were correctly found, code continued through all meta providers (which returned None). Now, after all three are found, it stops processing providers. There is still a case where the '?' will show in the add existing shows dialog on a few items, for sure if the indexer string is not in the nfo, and maybe another case, such as missing id or tvdbid string (will debug further)...

This leaves me with only a few shows needing manual processing when adding, rather than every series in my library like before.
