### PR TITLE
Fix quick adding of existing shows

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2847,7 +2847,7 @@ class NewHomeAddShows(MainHandler):
 
                 indexer_id = show_name = indexer = None
                 for cur_provider in sickbeard.metadata_provider_dict.values():
-                    if not (indexer_id and show_name and indexer):
+                    if not (indexer_id and show_name):
                         (indexer_id, show_name, indexer) = cur_provider.retrieveShowMetadata(cur_path)
 
                         # default to TVDB if indexer was not detected


### PR DESCRIPTION
Strips the year from the show name when manually adding, so the search box populates correctly and finds the show without having to remove the year and search again.

Fix error where indexer, indexer_id, and show_name were never returned in massAddTable.
After the values were correctly found, code continued through all meta providers (which returned None). Now, after enough info is found, it stops processing providers. There is still a case where the '?' will show in the add existing shows dialog on a few items, for sure if the indexer string is not in the nfo, and or if it is missing both id and tvdbid string...

This leaves me with only a few shows needing manual processing when adding, rather than every series in my library like before.
