### PR TITLE
Respect cache.

### DIFF
--- a/lib/tvrage_api/tvrage_api.py
+++ b/lib/tvrage_api/tvrage_api.py
@@ -101,15 +101,12 @@ class ShowContainer(dict):
 
         #keep only the 100th latest results
         if time.time() - self._lastgc > 20:
-            tbd = self._stack[:-100]
-            i = 0
-            for o in tbd:
+            for o in self._stack[:-100]:
                 del self[o]
-                del self._stack[i]
-                i += 1
+                
+            self._stack = self._stack[-100:]
 
-            _lastgc = time.time()
-            del tbd
+            self._lastgc = time.time()
 
         super(ShowContainer, self).__setitem__(key, value)
 

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -667,9 +667,9 @@ def get_all_episodes_from_absolute_number(show, absolute_numbers, indexer_id=Non
 def sanitizeSceneName(name, ezrss=False):
     """
     Takes a show name and returns the "scenified" version of it.
-    
+
     ezrss: If true the scenified version will follow EZRSS's cracksmoker rules as best as possible
-    
+
     Returns: A string containing the scene version of the show name given.
     """
 
@@ -900,7 +900,7 @@ def md5_for_file(filename, block_size=2 ** 16):
 
 def get_lan_ip():
     """
-    Simple function to get LAN localhost_ip 
+    Simple function to get LAN localhost_ip
     http://stackoverflow.com/questions/11735821/python-get-localhost-ip
     """
 
@@ -970,7 +970,7 @@ By Pedro Jose Pereira Vieito <pvieito@gmail.com> (@pvieito)
 * The keys should be unique for each device
 
 To add a new encryption_version:
-  1) Code your new encryption_version        
+  1) Code your new encryption_version
   2) Update the last encryption_version available in webserve.py
   3) Remember to maintain old encryption versions and key generators for retrocompatibility
 """
@@ -1164,8 +1164,12 @@ def mapIndexersToShow(showObj):
 
     # for each mapped entry
     for curResult in sqlResults:
-        logger.log(u"Found indexer mapping in cache for show: " + showObj.name, logger.DEBUG)
-        mapped[int(curResult['mindexer'])] = int(curResult['mindexer_id'])
+        nlist = [i for i in curResult if i is not None]
+        # Check if its mapped with both tvdb and tvrage.
+        if len(nlist) >= 4:
+            logger.log(u"Found indexer mapping in cache for show: " + showObj.name, logger.DEBUG)
+            mapped[int(curResult['mindexer'])] = int(curResult['mindexer_id'])
+            return mapped
     else:
         sql_l = []
         for indexer in sickbeard.indexerApi().indexers:


### PR DESCRIPTION
Tries to fix https://github.com/SiCKRAGETV/SickRage/issues/903

```
*** PROFILER RESULTS ***
call_dispatcher (C:\Users\x\AppData\Roaming\GitHub\SickRage\sickbeard\weba
pi.py:203)
function called 1 times

         1104340 function calls (1104332 primitive calls) in 3.503 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 620 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    3.503    3.503 webapi.py:203(call_dispatcher)
        1    0.024    0.024    3.499    3.499 webapi.py:2565(run)
      898    0.031    0.000    2.373    0.003 helpers.py:1153(mapIndexersToShow)

      899    0.003    0.000    1.143    0.001 db.py:208(select)
      899    0.019    0.000    1.140    0.001 db.py:171(action)
     1800    0.004    0.000    1.105    0.001 logger.py:329(log)
     1800    0.059    0.000    1.101    0.001 logger.py:261(log)
      449    0.009    0.000    0.616    0.001 webapi.py:2086(run)
      899    0.006    0.000    0.561    0.001 db.py:82(execute)
      899    0.002    0.000    0.537    0.001 db.py:96(_execute)
      899    0.534    0.001    0.534    0.001 {method 'execute' of 'sqlite3.Curs
or' objects}
      899    0.003    0.000    0.475    0.001 db.py:50(__init__)
      899    0.009    0.000    0.473    0.001 db.py:63(reconnect)
     1237    0.469    0.000    0.469    0.000 {nt.stat}
     1063    0.008    0.000    0.467    0.000 genericpath.py:26(isfile)
      899    0.442    0.000    0.442    0.000 {_sqlite3.connect}
     1800    0.008    0.000    0.428    0.000 __init__.py:1249(_log)
      449    0.002    0.000    0.406    0.001 helpers.py:213(findCertainShow)
      449    0.091    0.000    0.404    0.001 {filter}
       65    0.001    0.000    0.386    0.006 network_timezones.py:233(parse_dat
e_time)
       65    0.000    0.000    0.379    0.006 network_timezones.py:211(get_netwo
rk_timezone)
       64    0.004    0.000    0.379    0.006 tz.py:889(gettz)
       64    0.000    0.000    0.372    0.006 __init__.py:44(gettz)
      6/4    0.000    0.000    0.359    0.090 tarfile.py:2099(extractfile)
        6    0.003    0.000    0.358    0.060 tarfile.py:2352(_getmember)
        4    0.000    0.000    0.353    0.088 tarfile.py:1788(getmember)
        6    0.000    0.000    0.349    0.058 tarfile.py:1799(getmembers)
        4    0.002    0.000    0.349    0.087 tarfile.py:2375(_load)
     2420    0.009    0.000    0.348    0.000 tarfile.py:2303(next)
   201601    0.241    0.000    0.313    0.000 helpers.py:217(<lambda>)
     1800    0.005    0.000    0.294    0.000 __init__.py:1270(handle)
     1800    0.009    0.000    0.288    0.000 __init__.py:1302(callHandlers)
     2416    0.007    0.000    0.284    0.000 tarfile.py:1234(fromtarfile)
     1800    0.006    0.000    0.279    0.000 __init__.py:736(handle)
     1800    0.006    0.000    0.251    0.000 __init__.py:930(emit)
     1800    0.015    0.000    0.246    0.000 __init__.py:839(emit)
      899    0.002    0.000    0.228    0.000 logger.py:279(<lambda>)
      899    0.005    0.000    0.226    0.000 __init__.py:1198(log)
      908    0.004    0.000    0.216    0.000 __init__.py:1127(debug)
     2416    0.034    0.000    0.210    0.000 tarfile.py:1188(frombuf)
```
