### PR TITLE
[New GUI] Prevent Airdate column to wrap

### DIFF
--- a/gui/slick/interfaces/default/comingEpisodes.tmpl
+++ b/gui/slick/interfaces/default/comingEpisodes.tmpl
@@ -167,7 +167,7 @@
 		<tr>
 			<th>Airdate</th>
 			<th>Show</th>
-			<th class="nowrap">Next Ep</th>
+			<th nowrap="nowrap">Next Ep</th>
 			<th>Next Ep Name</th>
 			<th>Network</th>
 			<th>Quality</th>
@@ -206,7 +206,7 @@
 		<!-- start $cur_result['show_name'] //-->
 		<tr class="$show_div">
 			## forced to use a div to wrap airdate, the column sort went crazy with a span
-			<td align="center" class="nowrap">
+			<td align="center" nowrap="nowrap">
 				<div class="${fuzzydate}">$sbdatetime.sbdatetime.sbfdatetime($cur_result['localtime']).decode($sickbeard.SYS_ENCODING)</div><span class="sort_data">$time.mktime($cur_result['localtime'].timetuple())</span>
 			</td>
 
@@ -216,7 +216,7 @@
 #end if
 			</td>
 
-			<td class="nowrap" align="center">
+			<td nowrap="nowrap" align="center">
 				<%= 'S%02iE%02i' % (int(cur_result['season']), int(cur_result['episode'])) %>
 			</td>
 


### PR DESCRIPTION
As I posted here:
https://sickrage.tv/forums/forum/main-category/latest-news/8894-feedback-on-new-skin?p=11055#post11055

Working on Chrome and IE
