### PR TITLE
Fix invalid continuation byte for webapi

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -163,7 +163,7 @@ class Api(webserve.MainHandler):
     def _out_as_json(self, dict):
         self.set_header("Content-Type", "application/json")
         try:
-            out = json.dumps(dict, indent=self.intent, sort_keys=True)
+            out = json.dumps(dict, indent=self.intent,ensure_ascii=False,sort_keys=True)
             if 'jsonp' in self.request.query_arguments:
                 out = self.request.arguments['jsonp'] + '(' + out + ');'  # wrap with JSONP call if requested
 


### PR DESCRIPTION
I get this error when using API:
{"result":"error", "message": "error while composing output: "utf8 : terça 9:00  : error 3 : error 4 : invalid continuation byte"}

There's a special char "TERÇA"

Don't know why this happens. I had a special date style and even after change it to "yyyy-mm-dd" this error still happens. Don't know why the api builder is still using the translated week day. Also timezone is set to "network"

```
"data": {
    "missed": [
        {
            "airdate": "2014-11-18", 
            "airs": "terça 11:00 ", 
```

This error only happens when missing/future has "terça" - Tuesday and "sábado" - saturday weekdays. The other week days there's no special char.

https://docs.python.org/2/library/json.html
