### PR TITLE
Fixed up FreeBSD init file to use rc.subr

### DIFF
--- a/init.freebsd
+++ b/init.freebsd
@@ -9,29 +9,18 @@
 #
 # sickbeard_enable (bool):	Set to NO by default.
 #			Set it to YES to enable it.
-# sickbeard_user:  The user account SickRage daemon runs as what
+# sickbeard_user:	The user account SickRage daemon runs as what
 #			you want it to be. It uses '_sabnzbd' user by
 #			default. Do not sets it as empty or it will run
 #			as root.
+# sickbeard_group:	The group account SickRage daemon runs as what
+#			you want it to be. It uses '_sabnzbd' group by
+#			default. Do not sets it as empty or it will run
+#			as wheel.
 # sickbeard_dir:	Directory where SickRage lives.
 #			Default: /usr/local/sickbeard
-# sickbeard_chdir:  Change to this directory before running SickRage.
-#     Default is same as sickbeard_dir.
-# sickbeard_datadir:  Data directory for Sick Beard (DB, Logs, config)
-#     Default is same as sickbeard_chdir
-# sickbeard_pid:  The name of the pidfile to create.
-#     Default is sickbeard.pid in sickbeard_dir.
-# sickbeard_host: The hostname or IP SickRage is listening on
-#     Default is 127.0.0.1
-# sickbeard_port: The port SickRage is listening on
-#     Default is 8081
-# sickbeard_web_user: Username to authenticate to the SickRage web interface
-#     Default is an empty string (no username)
-# sickbeard_web_password: Password to authenticate to the SickRage web interface
-#     Default is an empty string (no password)
-# sickbeard_webroot: Set to value of web_root in config (for proxies etc)
-#     Default is an empty string (if set must start with a "/")
-PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
+# sickbeard_datadir:	Data directory for Sick Beard (DB, Logs, config)
+#			Default is same as sickbeard_dir
 
 . /etc/rc.subr
 
@@ -42,57 +31,26 @@ load_rc_config ${name}
 
 : ${sickbeard_enable:="NO"}
 : ${sickbeard_user:="_sabnzbd"}
+: ${sickbeard_group:="_sabnzbd"}
 : ${sickbeard_dir:="/usr/local/sickbeard"}
-: ${sickbeard_chdir:="${sickbeard_dir}"}
-: ${sickbeard_datadir:="${sickbeard_chdir}"}
-: ${sickbeard_pid:="${sickbeard_dir}/sickbeard.pid"}
-: ${sickbeard_host:="127.0.0.1"}
-: ${sickbeard_port:="8081"}
-: ${sickbeard_web_user:=""}
-: ${sickbeard_web_password:=""}
-: ${sickbeard_webroot:=""}
+: ${sickbeard_datadir:="${sickbeard_dir}"}
 
-status_cmd="${name}_status"
-stop_cmd="${name}_stop"
+pidfile="/var/run/sickbeard/sickbeard.pid"
+command="/usr/local/bin/python2.7"
+command_args="${sickbeard_dir}/SickBeard.py --datadir ${sickbeard_datadir} -d --pidfile ${pidfile} --quiet --nolaunch"
 
-command="/usr/sbin/daemon"
-command_args="-f -p ${sickbeard_pid} python ${sickbeard_dir}/SickBeard.py --quiet --nolaunch"
+start_precmd="sickbeard_prestart"
+sickbeard_prestart() {
+	if [ -f ${pidfile} ]; then
+		rm -f ${pidfile}
+		echo "Removing stale pidfile."
+	elif [ ! -d ${pidfile%/*} ]; then
+		install -d -o ${sickbeard_user} -g ${sickbeard_group} ${pidfile%/*}
+	fi
 
-# Add datadir to the command if set
-[ ! -z "${sickbeard_datadir}" ] && \
-  command_args="${command_args} --datadir ${sickbeard_datadir}"
-
-# Ensure user is root when running this script.
-if [ `id -u` != "0" ]; then
-  echo "Oops, you should be root before running this!"
-  exit 1
-fi
-
-verify_sickbeard_pid() {
-    # Make sure the pid corresponds to the SickRage process.
-    pid=`cat ${sickbeard_pid} 2>/dev/null`
-    ps -p ${pid} 2>/dev/null | grep -q "python ${sickbeard_dir}/SickBeard.py"
-    return $?
-}
-
-# Try to stop SickRage cleanly by calling shutdown over http.
-sickbeard_stop() {
-    echo "Stopping $name"
-    verify_sickbeard_pid
-    sickbeard_url="${sickbeard_host}:${sickbeard_port}"
-    [ ! -z "${sickbeard_web_user}" ] && \
-       sickbeard_url="${sickbeard_web_user}:${sickbeard_web_password}@${sickbeard_url}"
-    [ ! -z "${sickbeard_webroot}" ] && \
-       sickbeard_url="${sickbeard_url}${sickbeard_webroot}"
-    fetch -o - -q "http://${sickbeard_url}/home/shutdown/?pid=${pid}" >/dev/null
-    if [ -n "${pid}" ]; then
-      wait_for_pids ${pid}
-      echo "Stopped"
-    fi
-}
-
-sickbeard_status() {
-    verify_sickbeard_pid && echo "$name is running as ${pid}" || echo "$name is not running"
+	if [ ! -d ${sickbeard_datadir} ]; then
+		install -d -o ${sickbeard_user} -g ${sickbeard_group} ${sickbeard_datadir}
+	fi
 }
 
 run_rc_command "$1"


### PR DESCRIPTION
- Use FreeBSD's built in rc.subr instead of less robust custom, harder to maintain functions
- Install pidfile in better location
- Stale pidifle cleanup is needed because SickRage doesn't know to check a pidfile is stale (but prestart routine does and won't run if an existing pidfile is valid)
- Create data-directory with usable permissions if it doesn't exist
