### PR TITLE
Strip year from show title when adding existing shows, so show is found ...

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2876,18 +2876,19 @@ class NewHomeAddShows(MainHandler):
 
                 indexer_id = show_name = indexer = None
                 for cur_provider in sickbeard.metadata_provider_dict.values():
-                    (indexer_id, show_name, indexer) = cur_provider.retrieveShowMetadata(cur_path)
+                    if not (indexer_id and show_name):
+                        (indexer_id, show_name, indexer) = cur_provider.retrieveShowMetadata(cur_path)
 
-                    # default to TVDB if indexer was not detected
-                    if show_name and not (indexer or indexer_id):
-                        (sn, idx, id) = helpers.searchIndexerForShowID(show_name, indexer, indexer_id)
+                        # default to TVDB if indexer was not detected
+                        if show_name and not (indexer or indexer_id):
+                            (sn, idx, id) = helpers.searchIndexerForShowID(show_name, indexer, indexer_id)
 
-                        # set indexer and indexer_id from found info
-                        if not indexer and idx:
-                            indexer = idx
+                            # set indexer and indexer_id from found info
+                            if not indexer and idx:
+                                indexer = idx
 
-                        if not indexer_id and id:
-                            indexer_id = id
+                            if not indexer_id and id:
+                                indexer_id = id
 
                 cur_dir['existing_info'] = (indexer_id, show_name, indexer)
 
@@ -2921,7 +2922,7 @@ class NewHomeAddShows(MainHandler):
         if not show_dir:
             t.default_show_name = ''
         elif not show_name:
-            t.default_show_name = ek.ek(os.path.basename, ek.ek(os.path.normpath, show_dir)).replace('.', ' ')
+            t.default_show_name = re.sub(' \(\d{4}\)','', ek.ek(os.path.basename, ek.ek(os.path.normpath, show_dir)).replace('.', ' '))
         else:
             t.default_show_name = show_name
 


### PR DESCRIPTION
...on TVDB. Fix processing of NFO.

These are the two fixes I created a PR for on master (sorry).

For documentation sake, it stops indexer_id and show_name from being overwritten/cleared by subsequent providers in sickbeard.metadata_provider_dict.values() after the correct provider already was found. This fixes all of the '?' in the "Show Title" column on the massAddTable when adding shows, unless their nfo is missing the indexer key, or the nfo is missing entirely. \

NOTE: A fix should be added later so that after adding shows, the indexer key is set in existing nfo's, so that the next time the show needs to be added (db reset, reinstall, or other scenario) it is proper.

This also strips the (YEAR) off of "Showname (YEAR)" search string when adding existing shows, so that they are found in the initial search without user interaction. This fix only helps when your show folders have the year at the end and either indexer key is missing, or the nfo is missing/misread.
