### PR TITLE
Change TRAKT logger from ERROR to INFO

### DIFF
--- a/sickbeard/traktChecker.py
+++ b/sickbeard/traktChecker.py
@@ -54,7 +54,7 @@ class TraktChecker():
         library = TraktCall("user/library/shows/all.json/%API%/" + sickbeard.TRAKT_USERNAME, sickbeard.TRAKT_API, sickbeard.TRAKT_USERNAME, sickbeard.TRAKT_PASSWORD)
 
         if not library:
-            logger.log(u"Could not connect to trakt service, aborting library check", logger.ERROR)
+            logger.log(u"Could not connect to trakt service, aborting library check")
             return
 
         if not len(library):
@@ -107,7 +107,7 @@ class TraktChecker():
         watchlist = TraktCall("user/watchlist/shows.json/%API%/" + sickbeard.TRAKT_USERNAME, sickbeard.TRAKT_API, sickbeard.TRAKT_USERNAME, sickbeard.TRAKT_PASSWORD)
 
         if not watchlist:
-            logger.log(u"Could not connect to trakt service, aborting watchlist update", logger.ERROR)
+            logger.log(u"Could not connect to trakt service, aborting watchlist update")
             return
 
         if not len(watchlist):
@@ -141,7 +141,7 @@ class TraktChecker():
         watchlist = TraktCall("user/watchlist/episodes.json/%API%/" + sickbeard.TRAKT_USERNAME, sickbeard.TRAKT_API, sickbeard.TRAKT_USERNAME, sickbeard.TRAKT_PASSWORD)
 
         if not watchlist:
-            logger.log(u"Could not connect to trakt service, aborting watchlist update", logger.ERROR)
+            logger.log(u"Could not connect to trakt service, aborting watchlist update")
             return
 
         if not len(watchlist):


### PR DESCRIPTION
This happens when the server is over capacity. Don't know if is worth to change the code to check this over capacity status and put a re-try code after 10-15 seconds.

{"status": "failure","error": "server is over capacity"}

"If the server is over capacity, it will return a JSON error and set a HTTP/1.1 503 Service Unavailable http status. If you encounter this error, we recommend waiting 10 seconds or so, then retry the API call. This error typically indicates a temporary server issue that should resolve itself quickly, so the 2nd call will likely go through. Its worth putting a retry cap just to make sure it's not infinitely retrying in the event a true outage"

https://trakt.tv/api-docs/errors

Otherwise this will happen:
2014-11-26 08:14:07 TRAKTCHECKER :: Could not connect to trakt service, aborting watchlist update
2014-11-26 08:13:56 TRAKTCHECKER :: Could not connect to trakt service, aborting watchlist update
2014-11-25 20:52:45 TRAKTCHECKER :: Could not connect to trakt service, aborting watchlist update
2014-11-25 19:52:00 TRAKTCHECKER :: Could not connect to trakt service, aborting watchlist update
2014-11-25 18:52:29 TRAKTCHECKER :: Could not connect to trakt service, aborting watchlist update
2014-11-25 16:52:57 TRAKTCHECKER :: Could not connect to trakt service, aborting watchlist update
2014-11-25 16:52:27 TRAKTCHECKER :: Could not connect to trakt service, aborting watchlist update
