### PR TITLE
Add custom nzb category and torrent label for anime

### DIFF
--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -259,6 +259,16 @@
 									</span>
 								</label>
 							</div>
+
+                            <div class="field-pair">
+								<label>
+									<span class="component-title">Use SABnzbd category for anime</span>
+									<span class="component-desc">
+										<input type="text" name="sab_category_anime" id="sab_category_anime" value="$sickbeard.SAB_CATEGORY_ANIME" class="form-control input-sm input200" />
+										<p>add anime downloads to this category (e.g. anime)</p>
+									</span>
+								</label>
+							</div>
 						</div>
 
 						<div id="nzbget_settings">
@@ -310,6 +320,16 @@
 									<span class="component-desc">
 										<input type="text" name="nzbget_category" id="nzbget_category" value="$sickbeard.NZBGET_CATEGORY" class="form-control input-sm input200" />
 										<p>send downloads marked this category (e.g. TV)</p>
+									</span>
+								</label>
+							</div>
+
+                            <div class="field-pair">
+								<label>
+									<span class="component-title">Use NZBget category for anime</span>
+									<span class="component-desc">
+										<input type="text" name="nzbget_category_anime" id="nzbget_category_anime" value="$sickbeard.NZBGET_CATEGORY_ANIME" class="form-control input-sm input200" />
+										<p>send anime downloads marked this category (e.g. anime)</p>
 									</span>
 								</label>
 							</div>
@@ -462,6 +482,18 @@
 									<span class="component-desc">
 										<input type="text" name="torrent_label" id="torrent_label" value="$sickbeard.TORRENT_LABEL" class="form-control input-sm input200" />
 										<span id="label_warning_deluge" style="display:none"><p>(blank spaces are not allowed)</p>
+											<div class="clear-left"><p>note: label plugin must be enabled in Deluge clients</p></div>
+										</span>
+									</span>
+								</label>
+							</div>
+
+                            <div class="field-pair" id="torrent_label_anime_option">
+								<label>
+									<span class="component-title">Add label to torrent for anime</span>
+									<span class="component-desc">
+										<input type="text" name="torrent_label_anime" id="torrent_label_anime" value="$sickbeard.TORRENT_LABEL_ANIME" class="form-control input-sm input200" />
+										<span id="label_anime_warning_deluge" style="display:none"><p>(blank spaces are not allowed)</p>
 											<div class="clear-left"><p>note: label plugin must be enabled in Deluge clients</p></div>
 										</span>
 									</span>

--- a/gui/slick/js/configSearch.js
+++ b/gui/slick/js/configSearch.js
@@ -50,6 +50,7 @@ $(document).ready(function(){
 
         if ('blackhole' != selectedProvider) {
             var label_warning_deluge = '#label_warning_deluge',
+                label_anime_warning_deluge = '#label_anime_warning_deluge',
                 host_desc_rtorrent = '#host_desc_rtorrent',
                 host_desc_torrent = '#host_desc_torrent',
                 torrent_verify_cert_option = '#torrent_verify_cert_option',
@@ -57,10 +58,13 @@ $(document).ready(function(){
                 torrent_seed_time_option = '#torrent_seed_time_option',
                 torrent_high_bandwidth_option = '#torrent_high_bandwidth_option',
                 torrent_label_option = '#torrent_label_option',
+                torrent_label_anime_option = '#torrent_label_anime_option',
                 path_synology = '#path_synology',
                 torrent_paused_option = '#torrent_paused_option';
 
             $(label_warning_deluge).hide();
+            $(label_anime_warning_deluge).hide();
+            $(label_anime_warning_deluge).hide();
             $(host_desc_rtorrent).hide();
             $(host_desc_torrent).show();
             $(torrent_verify_cert_option).hide();
@@ -69,6 +73,7 @@ $(document).ready(function(){
             $(torrent_seed_time_option).hide();
             $(torrent_high_bandwidth_option).hide();
             $(torrent_label_option).show();
+            $(torrent_label_anime_option).show();
             $(path_synology).hide();
             $(torrent_paused_option).show();
 
@@ -81,15 +86,18 @@ $(document).ready(function(){
                 $(torrent_seed_time_option).show();
                 $(torrent_high_bandwidth_option).show();
                 $(torrent_label_option).hide();
+                $(torrent_label_anime_option).hide();
                 //$('#directory_title').text(client + directory);
             } else if ('deluge' == selectedProvider){
                 client = 'Deluge';
                 $(torrent_verify_cert_option).show();
                 $(label_warning_deluge).show();
+                $(label_anime_warning_deluge).show();
                 //$('#directory_title').text(client + directory);
             } else if ('download_station' == selectedProvider){
                 client = 'Synology DS';
                 $(torrent_label_option).hide();
+                $(torrent_label_anime_option).hide();
                 $('#torrent_paused_option').hide();
                 $(torrent_path_option).find('.fileBrowser').hide();
                 //$('#directory_title').text(client + directory);

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -255,11 +255,13 @@ SAB_USERNAME = None
 SAB_PASSWORD = None
 SAB_APIKEY = None
 SAB_CATEGORY = None
+SAB_CATEGORY_ANIME = None
 SAB_HOST = ''
 
 NZBGET_USERNAME = None
 NZBGET_PASSWORD = None
 NZBGET_CATEGORY = None
+NZBGET_CATEGORY_ANIME = None
 NZBGET_HOST = None
 NZBGET_USE_HTTPS = False
 NZBGET_PRIORITY = 100
@@ -272,6 +274,7 @@ TORRENT_SEED_TIME = None
 TORRENT_PAUSED = False
 TORRENT_HIGH_BANDWIDTH = False
 TORRENT_LABEL = ''
+TORRENT_LABEL_ANIME = ''
 TORRENT_VERIFY_CERT = False
 
 USE_XBMC = False
@@ -477,9 +480,9 @@ def initialize(consoleLogging=True):
 
         global BRANCH, GIT_REMOTE, GIT_REMOTE_URL, CUR_COMMIT_HASH, CUR_COMMIT_BRANCH, ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, ENCRYPTION_VERSION, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
             HANDLE_REVERSE_PROXY, USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, CHECK_PROPERS_INTERVAL, ALLOW_HIGH_PRIORITY, TORRENT_METHOD, \
-            SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
-            NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_PRIORITY, NZBGET_HOST, NZBGET_USE_HTTPS, backlogSearchScheduler, \
-            TORRENT_USERNAME, TORRENT_PASSWORD, TORRENT_HOST, TORRENT_PATH, TORRENT_SEED_TIME, TORRENT_PAUSED, TORRENT_HIGH_BANDWIDTH, TORRENT_LABEL, TORRENT_VERIFY_CERT, \
+            SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_CATEGORY_ANIME, SAB_HOST, \
+            NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_CATEGORY_ANIME, NZBGET_PRIORITY, NZBGET_HOST, NZBGET_USE_HTTPS, backlogSearchScheduler, \
+            TORRENT_USERNAME, TORRENT_PASSWORD, TORRENT_HOST, TORRENT_PATH, TORRENT_SEED_TIME, TORRENT_PAUSED, TORRENT_HIGH_BANDWIDTH, TORRENT_LABEL, TORRENT_LABEL_ANIME, TORRENT_VERIFY_CERT, \
             USE_XBMC, XBMC_ALWAYS_ON, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_NOTIFY_ONSUBTITLEDOWNLOAD, XBMC_UPDATE_FULL, XBMC_UPDATE_ONLYFIRST, \
             XBMC_UPDATE_LIBRARY, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, BACKLOG_FREQUENCY, \
             USE_TRAKT, TRAKT_USERNAME, TRAKT_PASSWORD, TRAKT_API, TRAKT_REMOVE_WATCHLIST, TRAKT_USE_WATCHLIST, TRAKT_METHOD_ADD, TRAKT_START_PAUSED, traktCheckerScheduler, TRAKT_USE_RECOMMENDED, TRAKT_SYNC, TRAKT_DEFAULT_INDEXER, TRAKT_REMOVE_SERIESLIST, \
@@ -745,11 +748,13 @@ def initialize(consoleLogging=True):
         SAB_PASSWORD = check_setting_str(CFG, 'SABnzbd', 'sab_password', '')
         SAB_APIKEY = check_setting_str(CFG, 'SABnzbd', 'sab_apikey', '')
         SAB_CATEGORY = check_setting_str(CFG, 'SABnzbd', 'sab_category', 'tv')
+        SAB_CATEGORY_ANIME = check_setting_str(CFG, 'SABnzbd', 'sab_category_anime', 'anime')
         SAB_HOST = check_setting_str(CFG, 'SABnzbd', 'sab_host', '')
 
         NZBGET_USERNAME = check_setting_str(CFG, 'NZBget', 'nzbget_username', 'nzbget')
         NZBGET_PASSWORD = check_setting_str(CFG, 'NZBget', 'nzbget_password', 'tegbzn6789')
         NZBGET_CATEGORY = check_setting_str(CFG, 'NZBget', 'nzbget_category', 'tv')
+        NZBGET_CATEGORY_ANIME = check_setting_str(CFG, 'NZBget', 'nzbget_category_anime', 'anime')
         NZBGET_HOST = check_setting_str(CFG, 'NZBget', 'nzbget_host', '')
         NZBGET_USE_HTTPS = bool(check_setting_int(CFG, 'NZBget', 'nzbget_use_https', 0))
         NZBGET_PRIORITY = check_setting_int(CFG, 'NZBget', 'nzbget_priority', 100)
@@ -762,6 +767,7 @@ def initialize(consoleLogging=True):
         TORRENT_PAUSED = bool(check_setting_int(CFG, 'TORRENT', 'torrent_paused', 0))
         TORRENT_HIGH_BANDWIDTH = bool(check_setting_int(CFG, 'TORRENT', 'torrent_high_bandwidth', 0))
         TORRENT_LABEL = check_setting_str(CFG, 'TORRENT', 'torrent_label', '')
+        TORRENT_LABEL_ANIME = check_setting_str(CFG, 'TORRENT', 'torrent_label_anime', '')
         TORRENT_VERIFY_CERT = bool(check_setting_int(CFG, 'TORRENT', 'torrent_verify_cert', 0))
 
         USE_XBMC = bool(check_setting_int(CFG, 'XBMC', 'use_xbmc', 0))
@@ -1588,6 +1594,7 @@ def save_config():
     new_config['SABnzbd']['sab_password'] = helpers.encrypt(SAB_PASSWORD, ENCRYPTION_VERSION)
     new_config['SABnzbd']['sab_apikey'] = SAB_APIKEY
     new_config['SABnzbd']['sab_category'] = SAB_CATEGORY
+    new_config['SABnzbd']['sab_category_anime'] = SAB_CATEGORY_ANIME
     new_config['SABnzbd']['sab_host'] = SAB_HOST
 
     new_config['NZBget'] = {}
@@ -1595,6 +1602,7 @@ def save_config():
     new_config['NZBget']['nzbget_username'] = NZBGET_USERNAME
     new_config['NZBget']['nzbget_password'] = helpers.encrypt(NZBGET_PASSWORD, ENCRYPTION_VERSION)
     new_config['NZBget']['nzbget_category'] = NZBGET_CATEGORY
+    new_config['NZBget']['nzbget_category_anime'] = NZBGET_CATEGORY_ANIME
     new_config['NZBget']['nzbget_host'] = NZBGET_HOST
     new_config['NZBget']['nzbget_use_https'] = int(NZBGET_USE_HTTPS)
     new_config['NZBget']['nzbget_priority'] = NZBGET_PRIORITY
@@ -1608,6 +1616,7 @@ def save_config():
     new_config['TORRENT']['torrent_paused'] = int(TORRENT_PAUSED)
     new_config['TORRENT']['torrent_high_bandwidth'] = int(TORRENT_HIGH_BANDWIDTH)
     new_config['TORRENT']['torrent_label'] = TORRENT_LABEL
+    new_config['TORRENT']['torrent_label_anime'] = TORRENT_LABEL_ANIME
     new_config['TORRENT']['torrent_verify_cert'] = int(TORRENT_VERIFY_CERT)
 
     new_config['XBMC'] = {}

--- a/sickbeard/clients/deluge.py
+++ b/sickbeard/clients/deluge.py
@@ -124,6 +124,8 @@ class DelugeAPI(GenericClient):
     def _set_torrent_label(self, result):
 
         label = sickbeard.TORRENT_LABEL
+        if result.show.is_anime:
+            label = sickbeard.TORRENT_LABEL_ANIME
         if ' ' in label:
             logger.log(self.name + u': Invalid label. Label must not contain a space', logger.ERROR)
             return False

--- a/sickbeard/clients/rtorrent.py
+++ b/sickbeard/clients/rtorrent.py
@@ -61,8 +61,11 @@ class rTorrentAPI(GenericClient):
                 return False
 
             # Set label
-            if sickbeard.TORRENT_LABEL:
-                torrent.set_custom(1, sickbeard.TORRENT_LABEL.lower())
+            label = sickbeard.TORRENT_LABEL
+            if result.show.is_anime:
+                label = sickbeard.TORRENT_LABEL_ANIME
+            if label:
+                torrent.set_custom(1, label.lower())
 
             if sickbeard.TORRENT_PATH:
                 torrent.set_directory(sickbeard.TORRENT_PATH)
@@ -97,8 +100,11 @@ class rTorrentAPI(GenericClient):
                 return False
 
             # Set label
-            if sickbeard.TORRENT_LABEL:
-                torrent.set_custom(1, sickbeard.TORRENT_LABEL.lower())
+            label = sickbeard.TORRENT_LABEL
+            if result.show.is_anime:
+                label = sickbeard.TORRENT_LABEL_ANIME
+            if label:
+                torrent.set_custom(1, label.lower())
 
             if sickbeard.TORRENT_PATH:
                 torrent.set_directory(sickbeard.TORRENT_PATH)

--- a/sickbeard/clients/utorrent.py
+++ b/sickbeard/clients/utorrent.py
@@ -58,10 +58,14 @@ class uTorrentAPI(GenericClient):
 
     def _set_torrent_label(self, result):
 
+        label = sickbeard.TORRENT_LABEL
+        if result.show.is_anime:
+            label = sickbeard.TORRENT_LABEL_ANIME
+
         params = {'action': 'setprops',
                   'hash': result.hash,
                   's': 'label',
-                  'v': sickbeard.TORRENT_LABEL
+                  'v': label
         }
         return self._request(params=params)
 

--- a/sickbeard/nzbget.py
+++ b/sickbeard/nzbget.py
@@ -37,6 +37,9 @@ from common import Quality
 def sendNZB(nzb, proper=False):
     addToTop = False
     nzbgetprio = 0
+    category = sickbeard.NZBGET_CATEGORY
+    if nzb.show.is_anime:
+        category = sickbeard.NZBGET_CATEGORY_ANIME
     
     if sickbeard.NZBGET_USE_HTTPS:
         nzbgetXMLrpc = "https://%(username)s:%(password)s@%(host)s/xmlrpc"
@@ -103,7 +106,7 @@ def sendNZB(nzb, proper=False):
         nzbget_version = helpers.tryInt(nzbget_version_str[:nzbget_version_str.find(".")])
         if nzbget_version == 0:
             if nzbcontent64 is not None:
-                nzbget_result = nzbGetRPC.append(nzb.name + ".nzb", sickbeard.NZBGET_CATEGORY, addToTop, nzbcontent64)
+                nzbget_result = nzbGetRPC.append(nzb.name + ".nzb", category, addToTop, nzbcontent64)
             else:
                 if nzb.resultType == "nzb":
                     genProvider = GenericProvider("")
@@ -111,27 +114,27 @@ def sendNZB(nzb, proper=False):
                     if (data == None):
                         return False
                     nzbcontent64 = standard_b64encode(data)
-                nzbget_result = nzbGetRPC.append(nzb.name + ".nzb", sickbeard.NZBGET_CATEGORY, addToTop, nzbcontent64)
+                nzbget_result = nzbGetRPC.append(nzb.name + ".nzb", category, addToTop, nzbcontent64)
         elif nzbget_version == 12:
             if nzbcontent64 is not None:
-                nzbget_result = nzbGetRPC.append(nzb.name + ".nzb", sickbeard.NZBGET_CATEGORY, nzbgetprio, False,
+                nzbget_result = nzbGetRPC.append(nzb.name + ".nzb", category, nzbgetprio, False,
                                                  nzbcontent64, False, dupekey, dupescore, "score")
             else:
-                nzbget_result = nzbGetRPC.appendurl(nzb.name + ".nzb", sickbeard.NZBGET_CATEGORY, nzbgetprio, False,
+                nzbget_result = nzbGetRPC.appendurl(nzb.name + ".nzb", category, nzbgetprio, False,
                                                     nzb.url, False, dupekey, dupescore, "score")
         # v13+ has a new combined append method that accepts both (url and content)
         # also the return value has changed from boolean to integer 
         # (Positive number representing NZBID of the queue item. 0 and negative numbers represent error codes.)
         elif nzbget_version >= 13:
             nzbget_result = True if nzbGetRPC.append(nzb.name + ".nzb", nzbcontent64 if nzbcontent64 is not None else nzb.url,
-                                                     sickbeard.NZBGET_CATEGORY, nzbgetprio, False, False, dupekey, dupescore,
+                                                     category, nzbgetprio, False, False, dupekey, dupescore,
                                                      "score") > 0 else False
         else:
             if nzbcontent64 is not None:
-                nzbget_result = nzbGetRPC.append(nzb.name + ".nzb", sickbeard.NZBGET_CATEGORY, nzbgetprio, False,
+                nzbget_result = nzbGetRPC.append(nzb.name + ".nzb", category, nzbgetprio, False,
                                                  nzbcontent64)
             else:
-                nzbget_result = nzbGetRPC.appendurl(nzb.name + ".nzb", sickbeard.NZBGET_CATEGORY, nzbgetprio, False,
+                nzbget_result = nzbGetRPC.appendurl(nzb.name + ".nzb", category, nzbgetprio, False,
                                                     nzb.url)
 
         if nzbget_result:

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -51,8 +51,11 @@ def sendNZB(nzb):
         params['ma_password'] = sickbeard.SAB_PASSWORD
     if sickbeard.SAB_APIKEY != None:
         params['apikey'] = sickbeard.SAB_APIKEY
-    if sickbeard.SAB_CATEGORY != None:
-        params['cat'] = sickbeard.SAB_CATEGORY
+    category = sickbeard.SAB_CATEGORY
+    if nzb.show.is_anime:
+        category = sickbeard.SAB_CATEGORY_ANIME
+    if category != None:
+        params['cat'] = category
 
     # use high priority if specified (recently aired episode)
     if nzb.priority == 1:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1669,14 +1669,14 @@ class ConfigSearch(MainHandler):
 
 
     def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, sab_username=None, sab_password=None,
-                   sab_apikey=None, sab_category=None, sab_host=None, nzbget_username=None, nzbget_password=None,
-                   nzbget_category=None, nzbget_priority=None, nzbget_host=None, nzbget_use_https=None,
-                   backlog_days=None, backlog_frequency=None, dailysearch_frequency=None,
-                   nzb_method=None, torrent_method=None, usenet_retention=None,
+                   sab_apikey=None, sab_category=None, sab_category_anime=None, sab_host=None, nzbget_username=None,
+                   nzbget_password=None, nzbget_category=None, nzbget_category_anime=None, nzbget_priority=None,
+                   nzbget_host=None, nzbget_use_https=None, backlog_days=None, backlog_frequency=None,
+                   dailysearch_frequency=None, nzb_method=None, torrent_method=None, usenet_retention=None,
                    download_propers=None, check_propers_interval=None, allow_high_priority=None,
                    backlog_startup=None, dailysearch_startup=None,
                    torrent_dir=None, torrent_username=None, torrent_password=None, torrent_host=None,
-                   torrent_label=None, torrent_path=None, torrent_verify_cert=None,
+                   torrent_label=None, torrent_label_anime=None, torrent_path=None, torrent_verify_cert=None,
                    torrent_seed_time=None, torrent_paused=None, torrent_high_bandwidth=None, ignore_words=None,
                    require_words=None):
 
@@ -1715,11 +1715,13 @@ class ConfigSearch(MainHandler):
         sickbeard.SAB_PASSWORD = sab_password
         sickbeard.SAB_APIKEY = sab_apikey.strip()
         sickbeard.SAB_CATEGORY = sab_category
+        sickbeard.SAB_CATEGORY_ANIME = sab_category_anime
         sickbeard.SAB_HOST = config.clean_url(sab_host)
 
         sickbeard.NZBGET_USERNAME = nzbget_username
         sickbeard.NZBGET_PASSWORD = nzbget_password
         sickbeard.NZBGET_CATEGORY = nzbget_category
+        sickbeard.NZBGET_CATEGORY_ANIME = nzbget_category_anime
         sickbeard.NZBGET_HOST = config.clean_host(nzbget_host)
         sickbeard.NZBGET_USE_HTTPS = config.checkbox_to_value(nzbget_use_https)
         sickbeard.NZBGET_PRIORITY = config.to_int(nzbget_priority, default=100)
@@ -1727,6 +1729,7 @@ class ConfigSearch(MainHandler):
         sickbeard.TORRENT_USERNAME = torrent_username
         sickbeard.TORRENT_PASSWORD = torrent_password
         sickbeard.TORRENT_LABEL = torrent_label
+        sickbeard.TORRENT_LABEL_ANIME = torrent_label_anime
         sickbeard.TORRENT_VERIFY_CERT = config.checkbox_to_value(torrent_verify_cert)
         sickbeard.TORRENT_PATH = torrent_path
         sickbeard.TORRENT_SEED_TIME = torrent_seed_time


### PR DESCRIPTION
Add a custom nzb category and custom torrent label for anime in the config search section.
When a show is marked as anime, the custom anime nzb category/torrent label will be used when sending the nzb/torrent to the download clients.
By doing this, anime shows can be processed separately from the normal tv shows.

This fixes https://github.com/SiCKRAGETV/SickRage/issues/947
