### PR TITLE
Issue with requests lib on debian

### DIFF
--- a/lib/requests/packages/urllib3/contrib/pyopenssl.py
+++ b/lib/requests/packages/urllib3/contrib/pyopenssl.py
@@ -57,11 +57,19 @@ __all__ = ['inject_into_urllib3', 'extract_from_urllib3']
 HAS_SNI = SUBJ_ALT_NAME_SUPPORT
 
 # Map from urllib3 to PyOpenSSL compatible parameter-values.
-_openssl_versions = {
-    ssl.PROTOCOL_SSLv23: OpenSSL.SSL.SSLv23_METHOD,
-    ssl.PROTOCOL_SSLv3: OpenSSL.SSL.SSLv3_METHOD,
-    ssl.PROTOCOL_TLSv1: OpenSSL.SSL.TLSv1_METHOD,
-}
+
+try:
+    _openssl_versions = {
+        ssl.PROTOCOL_SSLv23: OpenSSL.SSL.SSLv23_METHOD,
+        ssl.PROTOCOL_SSLv3: OpenSSL.SSL.SSLv3_METHOD,
+        ssl.PROTOCOL_TLSv1: OpenSSL.SSL.TLSv1_METHOD,
+     }
+except AttributeError:
+    _openssl_versions = {
+        ssl.PROTOCOL_SSLv23: OpenSSL.SSL.SSLv23_METHOD,
+        ssl.PROTOCOL_TLSv1: OpenSSL.SSL.TLSv1_METHOD,
+     }
+
 _openssl_verify = {
     ssl.CERT_NONE: OpenSSL.SSL.VERIFY_NONE,
     ssl.CERT_OPTIONAL: OpenSSL.SSL.VERIFY_PEER,


### PR DESCRIPTION
AttributeError: 'module' object has no attribute 'PROTOCOL_SSLv3'
Debian no longer includes this method by default.  I have patched the file to allow it to start without.  Updating requests will fix this as well
