### PR TITLE
Fix newznab error message when no "q" parameter

### DIFF
--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -282,7 +282,7 @@ class NewznabProvider(generic.NZBProvider):
         if search_params:
             params.update(search_params)
 
-        if 'rid' not in search_params and 'q' not in search_params:
+        if 'rid' not in search_params or 'q' not in search_params:
             logger.log("Error no rid or search term given. Report to forums with a full debug log")
             return []
 


### PR DESCRIPTION
Search URL has rid (TVRage id of the item being queried.) but not "q" parameter but still there's results because of the "rid".

From log: Search url: https://api.nzbgeek.info/api?apikey=***&season=7&maxage=300&cat=5030%2C5040&limit=100&attrs=rageid&offset=0&rid=123456&t=tvsearch

http://newznab.readthedocs.org/en/latest/misc/api/#tv-search

Don't merge this PR is the search URL must have the "q" parameter. The error should be fixed by adding the "q" to the search url. Or Is it by design?

https://sickrage.tv/forums/forum/help-support/bug-issue-reports/8634-error-no-rid-or-search-term-given-report-to-forums-with-a-full-debug-log
