### PR TITLE
Updated piratebay.py with oldpiratebay.org urls

### DIFF
--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -61,9 +61,9 @@ class ThePirateBayProvider(generic.TorrentProvider):
 
         self.proxy = ThePirateBayWebproxy()
 
-        self.url = 'http://pirateproxy.net/'
+        self.url = 'https://oldpiratebay.org/'
 
-        self.searchurl = self.url + 'search/%s/0/7/200'  # order by seed       
+        self.searchurl = self.url + 'search.php?q=%s&Torrent_sort=seeders.desc' # order by seed
 
         self.re_title_url = '/torrent/(?P<id>\d+)/(?P<title>.*?)//1".+?(?P<url>magnet.*?)//1".+?(?P<seeders>\d+)</td>.+?(?P<leechers>\d+)</td>'
 


### PR DESCRIPTION
Thanks to 'nizzle' who was so kind to provide these changes on SickRage forums: https://sickrage.tv/forums/forum/main-category/main-forum/15133-piratebay-down-way-to-use-oldpiratebay-org?p=15276#post15276
