### PR TITLE
Handle tvshows where there is only one actor (Issue #229)

### DIFF
--- a/lib/tvdb_api/tvdb_api.py
+++ b/lib/tvdb_api/tvdb_api.py
@@ -796,7 +796,10 @@ class Tvdb:
             log().debug('Actors result returned zero')
             return
 
-        actorsEt['actor'] = actorsEt['actor'] if type(actorsEt['actor']) is list else [ actorsEt['actor'] ]
+        if type(actorsEt['actor']) is dict:
+            log().debug('Single actor found, converting to list')
+            actorsEt['actor'] = [ actorsEt['actor'] ]
+
         cur_actors = Actors()
         for cur_actor in actorsEt['actor']:
             curActor = Actor()


### PR DESCRIPTION
As per the issue here:
https://github.com/SiCKRAGETV/sickrage-issues/issues/229

SickRage metadata handling does not seem to handle shows with only one actor returned by the tvdb API.
It calls items() on a dict.

I'm not a python guy, but the below fixed worked locally, basically just putting the 'actor' dict into a list if it is not already one.
