### PR TITLE
Fix displaying non ascii in log/error viewer

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1211,7 +1211,7 @@ class CMD_Logs(ApiCall):
 
         data = []
         if os.path.isfile(logger.logFile):
-            with ek(codecs.open, *[logger.logFile, 'r', 'utf-8']) as f:
+            with io.open(logger.logFile, 'r', encoding='utf-8') as f:
                 data = f.readlines()
 
         regex = r"^(\d\d\d\d)\-(\d\d)\-(\d\d)\s*(\d\d)\:(\d\d):(\d\d)\s*([A-Z]+)\s*(.+?)\s*\:\:\s*(.*)$"

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -17,13 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-import traceback
+import io
 import os
+import re
 import time
 import urllib
-import re
 import datetime
-import codecs
+import traceback
 
 import sickbeard
 from sickbeard import config, sab
@@ -4965,7 +4965,6 @@ class ErrorLogs(WebRoot):
             finalData = []
 
             for x in reversed(data_in):
-                x = ss(x)
                 match = re.match(regex, x)
 
                 if match:
@@ -5029,17 +5028,17 @@ class ErrorLogs(WebRoot):
         data = []
 
         if os.path.isfile(logger.logFile):
-            with ek(codecs.open, *[logger.logFile, 'r', 'utf-8']) as f:
+            with io.open(logger.logFile, 'r', encoding='utf-8') as f:
                 data = Get_Data(minLevel, f.readlines(), 0, regex, logFilter, logSearch, maxLines)
 
         for i in range(1, int(sickbeard.LOG_NR)):
             if os.path.isfile(logger.logFile + "." + str(i)) and (len(data) <= maxLines):
-                with ek(codecs.open, *[logger.logFile + "." + str(i), 'r', 'utf-8']) as f:
+                with io.open(logger.logFile + "." + str(i), 'r', encoding='utf-8') as f:
                     data += Get_Data(minLevel, f.readlines(), len(data), regex, logFilter, logSearch, maxLines)
 
         return t.render(
             header="Log File", title="Logs", topmenu="system",
-            logLines="".join(data), minLevel=minLevel, logNameFilters=logNameFilters,
+            logLines=u"".join(data), minLevel=minLevel, logNameFilters=logNameFilters,
             logFilter=logFilter, logSearch=logSearch)
 
     def submit_errors(self):


### PR DESCRIPTION
Remove mako error matching regex, to speed up issue submitter
Also return local encoding for windows in issue submitter (should work according to docs)
